### PR TITLE
feat(wallet): split website and app themes

### DIFF
--- a/agent-context/functional-spec.md
+++ b/agent-context/functional-spec.md
@@ -25,6 +25,7 @@ Genero is a multi-city, modular platform enabling the creation and operation of 
 - The "<open my wallet>" link is left aligned within the right margin.
 - Tagline appears as normal text with spacing below it.
 - Header split into three columns: blank left, centre matches body width with banner and right-aligned tagline, right column holds "<open my wallet>".
+- On mobile the tagline is hidden and a hamburger menu reveals a drawer from the right with the tagline and "<open my wallet>" button.
 - Extra top padding pushes the first section below the header.
 - Footer includes links to Whitepaper, Github and Contact, which opens a new contact page.
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,8 @@
+## v0.20
+- Hid tagline on small screens and added a hamburger-triggered drawer.
+- Drawer slides in from the right, shows the tagline and an "<open my wallet>" button.
+- Mobile header now shows banner and a menu icon.
+
 ## v0.19
 - Split the fixed header into three columns with empty left area.
 - Centre column matches body width and holds the banner and right-aligned tagline.

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -41,6 +41,7 @@
 - Tagline reads "Local Currency. Value = $3.35. Proceeds to charity." as plain text, right-aligned with margin below.
 - The first section includes extra top padding so content clears the fixed header.
 - Header split into three columns with left blank, centre column equal to body width containing banner and right-aligned tagline, right column with the "<open my wallet>" link.
+- On small screens the tagline is hidden, the banner fills the header and a hamburger menu opens a right-side drawer with the tagline and "<open my wallet>" link.
 - Footer now lists links to Whitepaper, Github and a new contact page.
 - All section headings use the `font-extrabold` class for extra emphasis.
 - Next.js config allows remote images from Supabase for the banner.

--- a/app/tcoin/wallet/layout.tsx
+++ b/app/tcoin/wallet/layout.tsx
@@ -2,7 +2,7 @@
 import { ModalProvider } from "@shared/contexts/ModalContext";
 import DarkModeProvider from "@shared/providers/dark-mode-provider";
 import { ReactQueryProvider } from "@shared/providers/react-query-provider";
-import "@tcoin/wallet/styles/app.scss";
+import "@tcoin/wallet/styles/website.scss";
 import type { Metadata } from "next";
 import ContentLayout from "./ContentLayout";
 import dynamic from "next/dynamic";
@@ -40,7 +40,7 @@ export default function RootLayout({
             line-height: 1.333;
             margin: 0;
             padding: 0 var(--margin-page, 20px);
-            color: var(--ui-primary, #000);
+            color: hsl(var(--foreground));
             text-wrap: pretty;
           }
           a {

--- a/app/tcoin/wallet/page.tsx
+++ b/app/tcoin/wallet/page.tsx
@@ -1,34 +1,105 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
+import { useState } from "react";
+
 export default function HomePage() {
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <>
       <div className="min-h-screen flex flex-col bg-white text-gray-800 text-base">
-      <header className="fixed top-0 left-0 w-full bg-white z-50 shadow-none border-none">
-        <div className="grid grid-cols-3 lg:[grid-template-columns:30%_40%_30%] items-start pb-1">
-          <div />
-          <div className="px-6">
+        <header className="fixed top-0 left-0 w-full bg-white z-50 shadow-none border-none">
+          <div className="sm:hidden flex items-start justify-between pb-1 px-6">
             <Image
               src="https://cspyqrxxyflnuwzzzkmv.supabase.co/storage/v1/object/public/website-images/tcoin-banner.png"
               alt="Toronto Coin banner"
               width={1920}
               height={600}
-              className="w-full"
+              className="flex-grow"
               priority
             />
-            <p className="text-right mb-2">
-              Local Currency. Value = $3.35. Proceeds to charity.
-            </p>
+            <button
+              type="button"
+              className="ml-2 p-2"
+              onClick={() => setMenuOpen(true)}
+            >
+              <span className="sr-only">Menu</span>
+              <svg
+                className="h-6 w-6"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 6h16M4 12h16M4 18h16"
+                />
+              </svg>
+            </button>
           </div>
-          <nav className="flex items-start justify-start px-6">
-            <Link href="/dashboard" className="no-underline">
-              &lt;open my wallet&gt;
-            </Link>
-          </nav>
-        </div>
-      </header>
-      <main className="flex-grow">
+          <div className="hidden sm:grid grid-cols-3 lg:[grid-template-columns:30%_40%_30%] items-start pb-1">
+            <div />
+            <div className="px-6">
+              <Image
+                src="https://cspyqrxxyflnuwzzzkmv.supabase.co/storage/v1/object/public/website-images/tcoin-banner.png"
+                alt="Toronto Coin banner"
+                width={1920}
+                height={600}
+                className="w-full"
+                priority
+              />
+              <p className="text-right mb-2">
+                Local Currency. Value = $3.35. Proceeds to charity.
+              </p>
+            </div>
+            <nav className="flex items-start justify-start px-6">
+              <Link href="/dashboard" className="no-underline">
+                &lt;open my wallet&gt;
+              </Link>
+            </nav>
+          </div>
+        </header>
+        {menuOpen && (
+          <div className="fixed inset-0 z-50 sm:hidden">
+            <button
+              type="button"
+              className="fixed inset-0 h-full w-full bg-black/50"
+              aria-label="Close menu"
+              onClick={() => setMenuOpen(false)}
+            />
+            <div className="fixed top-0 right-0 h-full w-2/3 bg-white text-black shadow-lg p-6 flex flex-col space-y-4">
+              <button
+                type="button"
+                className="self-end mb-4"
+                aria-label="Close menu"
+                onClick={() => setMenuOpen(false)}
+              >
+                <svg
+                  className="h-6 w-6"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+              <p>Local Currency.</p>
+              <p>Value = $3.35.</p>
+              <p>Proceeds to charity.</p>
+              <Link href="/dashboard" className="no-underline mt-auto">
+                &lt;open my wallet&gt;
+              </Link>
+            </div>
+          </div>
+        )}
+        <main className="flex-grow">
 
         <section id="future" className="pt-72 px-6 max-w-screen-xl mx-auto lg:w-2/5 lg:mx-[30%]">
           <h2 className="font-extrabold text-center my-5">The future of money is local</h2>

--- a/app/tcoin/wallet/styles/app.scss
+++ b/app/tcoin/wallet/styles/app.scss
@@ -1,3 +1,5 @@
+@config "../../../../tailwind.wallet-app.config.ts";
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Poppins:wght@400;700&display=swap');
 @import "@shared/styles/globals.scss";
 
 @tailwind base;
@@ -8,88 +10,88 @@
 
 @layer base {
   :root {
-    --background: 220 50% 95%; /* Light blue background */
-    --foreground: 220 40% 20%; /* Dark blue text */
+    --background: 0 0% 100%; /* White background */
+    --foreground: 0 0% 0%; /* Black text */
 
     --card: 220 50% 98%; /* Very light blue for cards */
-    --card-foreground: 220 40% 20%; /* Dark blue for card text */
+    --card-foreground: 0 0% 0%; /* Black card text */
 
     --popover: 220 50% 98%; /* Light blue for popovers */
-    --popover-foreground: 220 40% 20%; /* Dark blue for popover text */
+    --popover-foreground: 0 0% 0%; /* Black popover text */
 
-    --primary: 340 100% 60%; /* pink primary color */
-    --primary-foreground: 220 50% 95%; /* Light blue for primary text */
+    --primary: 340 100% 60%; /* Pink primary */
+    --primary-foreground: 0 0% 100%; /* White primary text */
 
-    --secondary: 220 60% 90%; /* Pale blue for secondary elements */
-    --secondary-foreground: 220 40% 30%; /* Darker blue for secondary text */
+    --secondary: 0 0% 80%; /* Light gray secondary */
+    --secondary-foreground: 0 0% 20%; /* Dark gray secondary text */
 
-    --muted: 220 40% 92%; /* Very light blue muted background */
-    --muted-foreground: 220 40% 45%; /* Medium blue for muted text */
+    --muted: 0 0% 90%; /* Light gray muted background */
+    --muted-foreground: 0 0% 40%; /* Gray muted text */
 
     --accent: 220 60% 80%; /* Soft blue accent */
-    --accent-foreground: 220 40% 20%; /* Dark blue accent text */
+    --accent-foreground: 0 0% 0%; /* Black accent text */
 
     --destructive: 0 84.2% 60.2%; /* Red for destructive actions */
-    --destructive-foreground: 210 40% 98%; /* White text for destructive actions */
+    --destructive-foreground: 0 0% 100%; /* White text for destructive actions */
 
     --border: 220 40% 85%; /* Light blue borders */
-    --input: 220 40% 85%; /* Light blue for input fields */
+    --input: 220 40% 85%; /* Light blue input fields */
 
     --ring: 220 70% 50%; /* Blue focus ring */
 
-    /* Link and header color */
-    --link-color: 340 100% 70%; /* Pink link color (#ff4081) */
-    --header-color: 340 100% 70%; /* Pink header color (#ff4081) */
+    /* Link and header colour */
+    --link-color: 340 100% 70%; /* Pink link colour (#ff4081) */
+    --header-color: 340 100% 70%; /* Pink header colour (#ff4081) */
 
-    /* Chart colors in shades of blue */
+    /* Chart colours */
     --chart-1: 210 100% 50%; /* Bright blue */
     --chart-2: 220 80% 60%; /* Light blue */
     --chart-3: 230 60% 40%; /* Dark blue */
-    --chart-4: 200 70% 50%; /* Muted blue */
-    --chart-5: 190 80% 60%; /* Light cyan */
+    --chart-4: 0 0% 70%; /* Gray */
+    --chart-5: 340 100% 70%; /* Pink */
 
     --radius: 0.5rem;
   }
   .dark {
-    --background: 220 30% 15%; /* Dark blue background */
-    --foreground: 220 80% 95%; /* Very light blue text */
+    --background: 0 0% 0%; /* Black background */
+    --foreground: 0 0% 100%; /* White text */
 
-    --card: 220 30% 20%; /* Darker blue for cards */
-    --card-foreground: 220 80% 95%; /* Light text on cards */
+    --card: 220 30% 20%; /* Dark blue cards */
+    --card-foreground: 0 0% 100%; /* White card text */
 
-    --popover: 220 30% 20%; /* Darker blue for popovers */
-    --popover-foreground: 220 80% 95%; /* Light text in popovers */
+    --popover: 220 30% 20%; /* Dark blue popovers */
+    --popover-foreground: 0 0% 100%; /* White popover text */
 
-    --primary: 340 100% 70%; /* Medium blue for primary elements */
-    --primary-foreground: 220 30% 95%; /* Very light blue for primary text */
+    --primary: 340 100% 70%; /* Pink primary */
+    --primary-foreground: 0 0% 0%; /* Black primary text */
 
-    --secondary: 220 40% 30%; /* Darker blue for secondary elements */
-    --secondary-foreground: 220 80% 95%; /* Very light blue for secondary text */
+    --secondary: 0 0% 40%; /* Dark gray secondary */
+    --secondary-foreground: 0 0% 100%; /* White secondary text */
 
-    --muted: 220 30% 25%; /* Muted dark blue */
-    --muted-foreground: 220 30% 60%; /* Medium-light blue for muted text */
+    --muted: 0 0% 25%; /* Muted dark gray */
+    --muted-foreground: 0 0% 75%; /* Light gray muted text */
 
     --accent: 220 80% 70%; /* Bright blue accent */
-    --accent-foreground: 220 30% 20%; /* Dark blue accent text */
+    --accent-foreground: 0 0% 0%; /* Black accent text */
 
-    --destructive: 0 84.2% 60.2%; /* Red for destructive actions */
-    --destructive-foreground: 210 40% 98%; /* White text for destructive actions */
+    --destructive: 0 84.2% 60.2%; /* Red destructive */
+    --destructive-foreground: 0 0% 100%; /* White destructive text */
 
-    --border: 220 30% 25%; /* Dark blue borders */
-    --input: 220 30% 25%; /* Dark blue for input fields */
+    --border: 0 0% 30%; /* Dark border */
+    --input: 0 0% 30%; /* Dark input */
 
-    --ring: 220 80% 95%; /* Light blue focus ring */
+    --ring: 0 0% 100%; /* White focus ring */
 
-    /* Link and header color */
-    --link-color: 340 100% 70%; /* Pink link color (#ff4081) */
-    --header-color: 340 100% 70%; /* Pink header color (#ff4081) */
+    /* Link and header colour */
+    --link-color: 340 100% 70%;
+    --header-color: 340 100% 70%;
 
-    /* Updated chart colors for blue theme */
+    /* Chart colours */
     --chart-1: 210 60% 50%; /* Medium blue */
     --chart-2: 220 50% 40%; /* Darker blue */
-    --chart-3: 230 40% 60%; /* Light blue */
-    --chart-4: 200 50% 30%; /* Dark blue */
-    --chart-5: 190 50% 70%; /* Very light blue */
+    --chart-3: 200 20% 60%; /* Gray */
+    --chart-4: 340 80% 60%; /* Pink */
+    --chart-5: 210 30% 70%; /* Light blue */
   }
 }
 
@@ -104,5 +106,19 @@
 
   svg {
     color: hsl(var(--primary));
+  }
+}
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-heading;
   }
 }

--- a/app/tcoin/wallet/styles/website.scss
+++ b/app/tcoin/wallet/styles/website.scss
@@ -1,0 +1,99 @@
+@config "../../../../tailwind.wallet-website.config.ts";
+@import "@shared/styles/globals.scss";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%; /* White background */
+    --foreground: 0 0% 0%; /* Black text */
+
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 0%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
+
+    --primary: 0 0% 0%; /* Black primary */
+    --primary-foreground: 0 0% 100%; /* White primary text */
+
+    --secondary: 0 0% 60%; /* Gray secondary */
+    --secondary-foreground: 0 0% 100%;
+
+    --muted: 0 0% 90%; /* Light gray muted background */
+    --muted-foreground: 0 0% 40%; /* Gray muted text */
+
+    --accent: 0 0% 0%; /* Black accent */
+    --accent-foreground: 0 0% 100%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 100%;
+
+    --border: 0 0% 80%;
+    --input: 0 0% 80%;
+    --ring: 0 0% 0%;
+
+    --link-color: 0 0% 0%;
+    --header-color: 0 0% 0%;
+
+    --chart-1: 0 0% 0%;
+    --chart-2: 0 0% 20%;
+    --chart-3: 0 0% 40%;
+    --chart-4: 0 0% 60%;
+    --chart-5: 0 0% 80%;
+
+    --radius: 0.5rem;
+  }
+  .dark {
+    --background: 0 0% 0%; /* Black background */
+    --foreground: 0 0% 100%; /* White text */
+
+    --card: 0 0% 10%;
+    --card-foreground: 0 0% 100%;
+
+    --popover: 0 0% 10%;
+    --popover-foreground: 0 0% 100%;
+
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+
+    --secondary: 0 0% 40%;
+    --secondary-foreground: 0 0% 100%;
+
+    --muted: 0 0% 20%;
+    --muted-foreground: 0 0% 80%;
+
+    --accent: 0 0% 100%;
+    --accent-foreground: 0 0% 0%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 100%;
+
+    --border: 0 0% 30%;
+    --input: 0 0% 30%;
+    --ring: 0 0% 100%;
+
+    --link-color: 0 0% 100%;
+    --header-color: 0 0% 100%;
+
+    --chart-1: 0 0% 100%;
+    --chart-2: 0 0% 80%;
+    --chart-3: 0 0% 60%;
+    --chart-4: 0 0% 40%;
+    --chart-5: 0 0% 20%;
+  }
+}
+
+@layer base {
+  a {
+    color: hsl(var(--primary));
+  }
+  .link-btn {
+    color: hsl(var(--primary));
+  }
+  svg {
+    color: hsl(var(--primary));
+  }
+}

--- a/tailwind.wallet-app.config.ts
+++ b/tailwind.wallet-app.config.ts
@@ -1,0 +1,19 @@
+import baseConfig from "./tailwind.config";
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  ...baseConfig,
+  theme: {
+    ...baseConfig.theme,
+    extend: {
+      ...(baseConfig.theme?.extend || {}),
+      fontFamily: {
+        ...(baseConfig.theme?.extend?.fontFamily || {}),
+        sans: ["Poppins", "sans-serif"],
+        heading: ["Montserrat", "sans-serif"],
+      },
+    },
+  },
+};
+
+export default config;

--- a/tailwind.wallet-website.config.ts
+++ b/tailwind.wallet-website.config.ts
@@ -1,0 +1,18 @@
+import baseConfig from "./tailwind.config";
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  ...baseConfig,
+  theme: {
+    ...baseConfig.theme,
+    extend: {
+      ...(baseConfig.theme?.extend || {}),
+      fontFamily: {
+        ...(baseConfig.theme?.extend?.fontFamily || {}),
+        sans: ["'Special Elite'", "monospace"],
+      },
+    },
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add wallet website and app tailwind configs
- introduce separate SCSS themes for wallet website and app
- wire wallet website to its own theme
- add responsive wallet website header with slide-out menu on mobile

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd741e86548324b29526e7fb5e99d3