### PR TITLE
fix(wallet): gate dashboard behind authentication

### DIFF
--- a/agent-context/functional-spec.md
+++ b/agent-context/functional-spec.md
@@ -44,6 +44,7 @@ Genero is a multi-city, modular platform enabling the creation and operation of 
 - Highlighted phrases in landing, resources and contact copy use a light grey background in light mode and a slightly lighter dark grey (Tailwind gray-700) background in dark mode.
 - Theme background colours are pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels enforce black backgrounds in dark mode.
 - Main panels derive their background from the theme variable instead of fixed white so they correctly switch to black in dark mode.
+- The dashboard is gated behind an authentication modal; closing it without signing in returns users to the landing page.
 
 ### 2. SpareChange
 

--- a/agent-context/functional-spec.md
+++ b/agent-context/functional-spec.md
@@ -44,7 +44,7 @@ Genero is a multi-city, modular platform enabling the creation and operation of 
 - Highlighted phrases in landing, resources and contact copy use a light grey background in light mode and a slightly lighter dark grey (Tailwind gray-700) background in dark mode.
 - Theme background colours are pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels enforce black backgrounds in dark mode.
 - Main panels derive their background from the theme variable instead of fixed white so they correctly switch to black in dark mode.
-- The dashboard is gated behind an authentication modal; closing it without signing in returns users to the landing page.
+- The dashboard is gated behind an authentication modal that opens only once; closing it without signing in returns users to the landing page.
 
 ### 2. SpareChange
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.38
+- Memoised modal context callbacks so the sign-in modal opens once and avoids infinite render loops.
+
 ## v0.37
 - Redirect unauthenticated wallet dashboard visits to the landing page after closing the sign-in modal.
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.37
+- Redirect unauthenticated wallet dashboard visits to the landing page after closing the sign-in modal.
+
 ## v0.36
 - Locked wallet dashboard QR code colours to black on white.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -66,3 +66,4 @@
 - Hamburger icon in the landing header uses #05656F in light mode.
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
+- Unauthenticated visits to `/dashboard` trigger the sign-in modal and closing it without signing in redirects to `/tcoin/wallet`.

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -67,3 +67,4 @@
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
 - Unauthenticated visits to `/dashboard` trigger the sign-in modal and closing it without signing in redirects to `/tcoin/wallet`.
+- Modal context callbacks are memoised so the sign-in modal opens only once per unauthenticated dashboard visit.

--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -14,7 +14,7 @@ import "react-toastify/dist/ReactToastify.css";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const { isLoading, isAuthenticated } = useAuth();
-  const { openModal, closeModal } = useModal();
+  const { openModal, closeModal, isOpen } = useModal();
   const router = useRouter();
   const pathname = usePathname();
   const publicPaths = ["/tcoin/wallet", "/tcoin/wallet/resources", "/tcoin/wallet/contact"];
@@ -33,7 +33,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   }, [closeModal, router]);
 
   useEffect(() => {
-    if (isLoading || isAuthenticated) return;
+    if (isLoading || isAuthenticated || isOpen) return;
 
     if (pathname === "/tcoin/wallet/dashboard") {
       openModal({
@@ -48,7 +48,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     } else if (!isPublic) {
       router.push("/tcoin/wallet");
     }
-  }, [handleModalClose, isAuthenticated, isLoading, isPublic, openModal, pathname, router]);
+  }, [handleModalClose, isAuthenticated, isLoading, isOpen, isPublic, openModal, pathname, router]);
 
   if (isLoading) {
     return <div className={bodyClass}>...loading </div>;

--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -2,16 +2,19 @@
 "use client";
 
 import { useAuth } from "@shared/api/hooks/useAuth";
+import { useModal } from "@shared/contexts/ModalContext";
 import { cn } from "@shared/utils/classnames";
 import { Footer } from "@tcoin/wallet/components/footer";
+import SignInModal from "@tcoin/wallet/components/modals/SignInModal";
 import Navbar from "@tcoin/sparechange/components/navbar/Navbar";
-import { useRouter, usePathname } from "next/navigation";
-import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
 import { Flip, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const { isLoading, isAuthenticated } = useAuth();
+  const { openModal, closeModal } = useModal();
   const router = useRouter();
   const pathname = usePathname();
   const publicPaths = ["/tcoin/wallet", "/tcoin/wallet/resources", "/tcoin/wallet/contact"];
@@ -24,13 +27,28 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     "text-foreground text-sm"
   );
 
-  useEffect(() => {
-    // Replace this with your actual authentication logic
+  const handleModalClose = useCallback(() => {
+    closeModal();
+    router.push("/tcoin/wallet");
+  }, [closeModal, router]);
 
-    if (!isLoading && !isAuthenticated && !isPublic) {
-      router.push("/");
+  useEffect(() => {
+    if (isLoading || isAuthenticated) return;
+
+    if (pathname === "/tcoin/wallet/dashboard") {
+      openModal({
+        content: (
+          <SignInModal
+            closeModal={handleModalClose}
+            extraObject={{ isSignIn: true }}
+          />
+        ),
+        elSize: "4xl",
+      });
+    } else if (!isPublic) {
+      router.push("/tcoin/wallet");
     }
-  }, [isAuthenticated, isLoading, isPublic, router]);
+  }, [handleModalClose, isAuthenticated, isLoading, isPublic, openModal, pathname, router]);
 
   if (isLoading) {
     return <div className={bodyClass}>...loading </div>;

--- a/shared/contexts/ModalContext.tsx
+++ b/shared/contexts/ModalContext.tsx
@@ -1,7 +1,13 @@
 "use client";
 // ModalContext.tsx
 import Modal from "@shared/components/ui/Modal";
-import React, { createContext, ReactNode, useContext, useState } from "react";
+import React, {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react";
 
 export interface ModalContentType {
   content?: ReactNode | null;
@@ -35,15 +41,24 @@ export const ModalProvider: React.FC<ModalProviderProps> = ({ children }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [modalContent, setModalContent] = useState<ModalContentType | null>(null);
 
-  const openModal = ({ content = null, title = "", description = "", elSize = "md", isResponsive = false }: ModalContentType) => {
-    setModalContent({ content, title, elSize, isResponsive, description });
-    setIsOpen(true);
-  };
+  const openModal = useCallback(
+    ({
+      content = null,
+      title = "",
+      description = "",
+      elSize = "md",
+      isResponsive = false,
+    }: ModalContentType) => {
+      setModalContent({ content, title, elSize, isResponsive, description });
+      setIsOpen(true);
+    },
+    []
+  );
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsOpen(false);
     setModalContent(null);
-  };
+  }, []);
 
   return (
     <ModalContext.Provider value={{ isOpen, modalContent, openModal, closeModal }}>


### PR DESCRIPTION
## Summary
- show sign-in modal when unauthenticated users access `/tcoin/wallet/dashboard`
- redirect to landing page if the sign-in modal is dismissed without authentication
- document dashboard authentication requirements in specs

## Testing
- `pnpm lint`
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9fbf400832481495b2da82e7de3