### PR TITLE
feat: simplify wallet routing and navigation

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,8 @@
+## v0.39
+- Removed wallet path prefixes so resources and contact live at root and unauthenticated dashboard visits return home.
+- Landing page "Open My Wallet" checks authentication and opens the sign-in modal instead of routing when needed.
+- Dashboard footer replaced with a fixed tab bar for Home, Receive, Send, Contacts and More.
+
 ## v0.38
 - Memoised modal context callbacks so the sign-in modal opens once and avoids infinite render loops.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -66,5 +66,9 @@
 - Hamburger icon in the landing header uses #05656F in light mode.
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
-- Unauthenticated visits to `/dashboard` trigger the sign-in modal and closing it without signing in redirects to `/tcoin/wallet`.
+- Unauthenticated visits to `/dashboard` trigger the sign-in modal and closing it without signing in redirects to `/`.
 - Modal context callbacks are memoised so the sign-in modal opens only once per unauthenticated dashboard visit.
+- "Open My Wallet" checks authentication and opens the sign-in modal on the landing page when needed.
+- Internal links drop the `/tcoin/wallet` prefix so resources and contact live at `/resources` and `/contact`.
+- Dashboard footer replaced with a fixed bottom navigation for Home, Receive, Send, Contacts and More; the More menu slides up from the bottom-right with top up, cash out, default charity, profile and theme options.
+- The fixed navigation is visible on all screen sizes and the dashboard home tab shows the full grid on desktop and just the balance on mobile.

--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -17,7 +17,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const { openModal, closeModal, isOpen } = useModal();
   const router = useRouter();
   const pathname = usePathname();
-  const publicPaths = ["/tcoin/wallet", "/tcoin/wallet/resources", "/tcoin/wallet/contact"];
+  const publicPaths = ["/", "/resources", "/contact"];
   const isPublic = publicPaths.includes(pathname);
 
   const bodyClass = cn(
@@ -29,13 +29,13 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
 
   const handleModalClose = useCallback(() => {
     closeModal();
-    router.push("/tcoin/wallet");
+    router.push("/");
   }, [closeModal, router]);
 
   useEffect(() => {
     if (isLoading || isAuthenticated || isOpen) return;
 
-    if (pathname === "/tcoin/wallet/dashboard") {
+    if (pathname === "/dashboard") {
       openModal({
         content: (
           <SignInModal
@@ -46,7 +46,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
         elSize: "4xl",
       });
     } else if (!isPublic) {
-      router.push("/tcoin/wallet");
+      router.push("/");
     }
   }, [handleModalClose, isAuthenticated, isLoading, isOpen, isPublic, openModal, pathname, router]);
 
@@ -58,7 +58,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     <section className={bodyClass}>
       {!isPublic && <Navbar title="TCOIN" />}
       <div className={cn(!isPublic && "flex-grow flex flex-col pt-16 bg-background text-foreground")}>{children}</div>
-      <Footer />
+      {isPublic && <Footer />}
       {!isPublic && (
         <ToastContainer autoClose={3000} transition={Flip} theme="colored" />
       )}

--- a/app/tcoin/wallet/components/footer/Footer.tsx
+++ b/app/tcoin/wallet/components/footer/Footer.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 export function Footer() {
   return (
-    <footer className={cn("py-6 w-full", "bg-background", "text-foreground")}> 
+    <footer className={cn("py-6 w-full", "bg-background", "text-foreground")}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center">
           <div>
@@ -11,9 +11,9 @@ export function Footer() {
             <h5>&copy; {new Date().getFullYear()} Toronto Coin. All rights reserved.</h5>
           </div>
           <div className="space-x-4 text-sm">
-            <Link href="/tcoin/wallet/resources">Resources</Link>
+            <Link href="/resources">Resources</Link>
             <Link href="https://github.com/GreenPill-TO/TorontoCoin">Github</Link>
-            <Link href="/tcoin/wallet/contact">Contact</Link>
+            <Link href="/contact">Contact</Link>
           </div>
         </div>
       </div>

--- a/app/tcoin/wallet/dashboard/page.tsx
+++ b/app/tcoin/wallet/dashboard/page.tsx
@@ -1,39 +1,29 @@
 "use client";
 import { useAuth } from "@shared/api/hooks/useAuth";
 import { useEffect, useMemo } from "react";
-import { WalletScreen } from "../../sparechange/dashboard/screens/WalletScreen";
+import { WalletScreen } from "./screens";
 import { useRouter } from "next/navigation";
 
 export default function Dashboard() {
   const { userData, error, isLoadingUser } = useAuth();
 
   const mainClass = "p-4 sm:p-8 bg-background text-foreground min-h-screen";
-  const router = useRouter()
+  const router = useRouter();
 
   const screenContent = useMemo(() => {
     if (isLoadingUser || error) return null;
 
     switch (userData?.cubidData?.persona) {
-      // case "ph":
-      //   return <PanhandlerScreen />;
-      // case "dr":
-      //   return <DonorScreen />;
       default:
-        return (
-          <WalletScreen
-            qrBgColor="#fff"
-            qrFgColor="#000"
-            qrWrapperClassName="bg-white p-1"
-            tokenLabel="TCOIN"
-          />
-        );
+        return <WalletScreen />;
     }
-  }, [userData]);
+  }, [userData, error, isLoadingUser]);
+
   useEffect(() => {
     if (Boolean(userData?.cubidData?.full_name)) {
-      router.replace('/dashboard')
+      router.replace("/dashboard");
     }
-  }, [userData, router])
+  }, [userData, router]);
 
   if (error) {
     return <div className={mainClass}>Error loading data: {error.message}</div>;

--- a/app/tcoin/wallet/page.tsx
+++ b/app/tcoin/wallet/page.tsx
@@ -1,8 +1,27 @@
 "use client";
 import Link from "next/link";
 import { LandingHeader } from "@tcoin/wallet/components/landing-header";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@shared/api/hooks/useAuth";
+import { useModal } from "@shared/contexts/ModalContext";
+import SignInModal from "@tcoin/wallet/components/modals/SignInModal";
 
 export default function HomePage() {
+  const { isAuthenticated } = useAuth();
+  const { openModal, closeModal } = useModal();
+  const router = useRouter();
+
+  const handleOpenWallet = () => {
+    if (isAuthenticated) {
+      router.push("/dashboard");
+    } else {
+      openModal({
+        content: <SignInModal closeModal={closeModal} extraObject={{ isSignIn: true }} />,
+        elSize: "4xl",
+      });
+    }
+  };
+
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground text-base">
       <LandingHeader />
@@ -110,7 +129,7 @@ export default function HomePage() {
           <h2 className="font-extrabold text-center my-5">How to Get Involved</h2>
           <div className="space-y-4">
             <p>
-              <span className="bg-gray-200 dark:bg-gray-700 px-1">Sign up.</span> <Link href="/tcoin/wallet/contact">Join the mailing list</Link> and get early access to buy TCOINs.
+              <span className="bg-gray-200 dark:bg-gray-700 px-1">Sign up.</span> <Link href="/contact">Join the mailing list</Link> and get early access to buy TCOINs.
             </p>
             <p>
               <span className="bg-gray-200 dark:bg-gray-700 px-1">Help build it.</span> We’re a grassroots team. <Link href="https://t.me/+EPRHfB_R2kkzZDlh">Message us on Telegram</Link>.
@@ -140,12 +159,12 @@ export default function HomePage() {
             We’re building one.
           </p>
           <div className="text-center my-6">
-            <Link
-              href="/dashboard"
-              className="inline-block px-4 py-2 bg-[#05656F] text-white dark:bg-white dark:text-black no-underline"
+            <button
+              onClick={handleOpenWallet}
+              className="inline-block px-4 py-2 bg-[#05656F] text-white dark:bg-white dark:text-black"
             >
               &lt;open my wallet&gt;
-            </Link>
+            </button>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary
- gate wallet access behind auth modal on landing page
- flatten wallet routes and replace dashboard footer with fixed tab bar

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb520388483249ee30a3e5ebc6da5