### PR TITLE
fix(wallet): remove nested path prefix

### DIFF
--- a/agent-context/functional-spec.md
+++ b/agent-context/functional-spec.md
@@ -44,6 +44,7 @@ Genero is a multi-city, modular platform enabling the creation and operation of 
 - Highlighted phrases in landing, resources and contact copy use a light grey background in light mode and a slightly lighter dark grey (Tailwind gray-700) background in dark mode.
 - Theme background colours are pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels enforce black backgrounds in dark mode.
 - Main panels derive their background from the theme variable instead of fixed white so they correctly switch to black in dark mode.
+- Wallet routes are available from the domain root so links use paths like `/dashboard` rather than `/tcoin/wallet/dashboard`.
 
 ### 2. SpareChange
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.38
+- Removed '/tcoin/wallet' prefix from wallet links so routes serve from the domain root.
+
 ## v0.37
 - Capitalised wallet dashboard branding to TCOIN and added optional QR padding.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -66,3 +66,4 @@
 - Hamburger icon in the landing header uses #05656F in light mode.
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
+- Internal links use root-relative URLs and rewrites map them to the wallet app, eliminating `/tcoin/wallet` from page paths.

--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -14,7 +14,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   const { isLoading, isAuthenticated } = useAuth();
   const router = useRouter();
   const pathname = usePathname();
-  const publicPaths = ["/tcoin/wallet", "/tcoin/wallet/resources", "/tcoin/wallet/contact"];
+  const publicPaths = ["/", "/resources", "/contact"];
   const isPublic = publicPaths.includes(pathname);
 
   const bodyClass = cn(

--- a/app/tcoin/wallet/components/footer/Footer.tsx
+++ b/app/tcoin/wallet/components/footer/Footer.tsx
@@ -11,9 +11,9 @@ export function Footer() {
             <h5>&copy; {new Date().getFullYear()} Toronto Coin. All rights reserved.</h5>
           </div>
           <div className="space-x-4 text-sm">
-            <Link href="/tcoin/wallet/resources">Resources</Link>
+            <Link href="/resources">Resources</Link>
             <Link href="https://github.com/GreenPill-TO/TorontoCoin">Github</Link>
-            <Link href="/tcoin/wallet/contact">Contact</Link>
+            <Link href="/contact">Contact</Link>
           </div>
         </div>
       </div>

--- a/app/tcoin/wallet/page.tsx
+++ b/app/tcoin/wallet/page.tsx
@@ -110,7 +110,7 @@ export default function HomePage() {
           <h2 className="font-extrabold text-center my-5">How to Get Involved</h2>
           <div className="space-y-4">
             <p>
-              <span className="bg-gray-200 dark:bg-gray-700 px-1">Sign up.</span> <Link href="/tcoin/wallet/contact">Join the mailing list</Link> and get early access to buy TCOINs.
+              <span className="bg-gray-200 dark:bg-gray-700 px-1">Sign up.</span> <Link href="/contact">Join the mailing list</Link> and get early access to buy TCOINs.
             </p>
             <p>
               <span className="bg-gray-200 dark:bg-gray-700 px-1">Help build it.</span> We’re a grassroots team. <Link href="https://t.me/+EPRHfB_R2kkzZDlh">Message us on Telegram</Link>.


### PR DESCRIPTION
## Summary
- drop `/tcoin/wallet` from internal links so wallet pages resolve at the domain root
- update specs and session log for root-level wallet paths

## Testing
- `pnpm lint`
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03c811e308324aad0ff3fae8bf3f0