### PR TITLE
feat(wallet): allow unauthenticated dashboard access

### DIFF
--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -7,15 +7,18 @@ import { Footer } from "@tcoin/wallet/components/footer";
 import Navbar from "@tcoin/sparechange/components/navbar/Navbar";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
+import useRequireAuthOnDashboard from "./useRequireAuthOnDashboard";
 import { Flip, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const { isLoading, isAuthenticated } = useAuth();
+  const { requireAuth, loading } = useRequireAuthOnDashboard();
   const router = useRouter();
   const pathname = usePathname();
   const publicPaths = ["/", "/resources", "/contact"];
-  const isPublic = publicPaths.includes(pathname);
+  const isDashboardPublic = pathname === "/dashboard" && !requireAuth;
+  const isPublic = publicPaths.includes(pathname) || isDashboardPublic;
 
   const bodyClass = cn(
     "min-h-screen",
@@ -27,10 +30,10 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   useEffect(() => {
     // Replace this with your actual authentication logic
 
-    if (!isLoading && !isAuthenticated && !isPublic) {
+    if (!isLoading && !isAuthenticated && !isPublic && !loading) {
       router.push("/");
     }
-  }, [isAuthenticated, isLoading, isPublic, router]);
+  }, [isAuthenticated, isLoading, isPublic, loading, router]);
 
   if (isLoading) {
     return <div className={bodyClass}>...loading </div>;

--- a/app/tcoin/wallet/useRequireAuthOnDashboard.test.ts
+++ b/app/tcoin/wallet/useRequireAuthOnDashboard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRequireAuth } from './useRequireAuthOnDashboard'
+
+describe('shouldRequireAuth', () => {
+  it('returns true for truthy values', () => {
+    expect(shouldRequireAuth('true')).toBe(true)
+    expect(shouldRequireAuth('TRUE')).toBe(true)
+    expect(shouldRequireAuth(1)).toBe(true)
+    expect(shouldRequireAuth('1')).toBe(true)
+    expect(shouldRequireAuth(true)).toBe(true)
+  })
+
+  it('returns false for other values', () => {
+    expect(shouldRequireAuth('false')).toBe(false)
+    expect(shouldRequireAuth(false)).toBe(false)
+    expect(shouldRequireAuth(0)).toBe(false)
+    expect(shouldRequireAuth('0')).toBe(false)
+    expect(shouldRequireAuth(undefined)).toBe(false)
+  })
+})

--- a/app/tcoin/wallet/useRequireAuthOnDashboard.ts
+++ b/app/tcoin/wallet/useRequireAuthOnDashboard.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react'
+
+export function shouldRequireAuth(value: unknown): boolean {
+  return value === true || value === 'true' || value === 'TRUE' || value === 1 || value === '1'
+}
+
+export default function useRequireAuthOnDashboard() {
+  const [requireAuth, setRequireAuth] = useState(true)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchFlag = async () => {
+      const { createClient } = await import('@shared/lib/supabase/client')
+      const supabase = createClient()
+      const { data, error } = await supabase
+        .from('control_variables')
+        .select('value')
+        .eq('variable', 'require_authenticated_on_dashboard')
+        .single()
+
+      if (!error) {
+        setRequireAuth(shouldRequireAuth(data?.value))
+      }
+      setLoading(false)
+    }
+
+    fetchFlag()
+  }, [])
+
+  return { requireAuth, loading }
+}


### PR DESCRIPTION
## Summary
- allow `/tcoin/wallet/dashboard` access when control variable does not require authentication
- add hook to fetch `require_authenticated_on_dashboard`
- add unit test for control variable parsing

## Testing
- `pnpm lint`
- `pnpm dlx vitest run app/tcoin/wallet/useRequireAuthOnDashboard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c05fafb4588324914723c6cf9f545c