### PR TITLE
feat(wallet): allow unauthenticated dashboard access

### DIFF
--- a/agent-context/functional-spec.md
+++ b/agent-context/functional-spec.md
@@ -45,6 +45,7 @@ Genero is a multi-city, modular platform enabling the creation and operation of 
 - Theme background colours are pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels enforce black backgrounds in dark mode.
 - Main panels derive their background from the theme variable instead of fixed white so they correctly switch to black in dark mode.
 - Wallet routes are available from the domain root so links use paths like `/dashboard` rather than `/tcoin/wallet/dashboard`.
+- Unauthenticated visitors may open `/dashboard` directly when control variable `require_authenticated_on_dashboard` is not `true`, `TRUE` or `1`.
 
 ### 2. SpareChange
 

--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,7 @@
+## v0.39
+- Fetch latest `require_authenticated_on_dashboard` control variable so unauthenticated `/dashboard` links stop redirecting.
+- Trim trailing slashes from wallet-relative paths.
+
 ## v0.38
 - Removed '/tcoin/wallet' prefix from wallet links so routes serve from the domain root.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -67,3 +67,4 @@
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
 - Internal links use root-relative URLs and rewrites map them to the wallet app, eliminating `/tcoin/wallet` from page paths.
+- Dashboard authentication toggles via Supabase control variable `require_authenticated_on_dashboard`; `/dashboard` stays public unless that value is `true`, `TRUE` or `1`.

--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -7,15 +7,20 @@ import { Footer } from "@tcoin/wallet/components/footer";
 import Navbar from "@tcoin/sparechange/components/navbar/Navbar";
 import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
+import useRequireAuthOnDashboard from "./useRequireAuthOnDashboard";
 import { Flip, ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import { walletRelativePath } from "./path";
 
 export default function ClientLayout({ children }: { children: React.ReactNode }) {
   const { isLoading, isAuthenticated } = useAuth();
+  const { requireAuth, loading } = useRequireAuthOnDashboard();
   const router = useRouter();
   const pathname = usePathname();
+  const relativePath = walletRelativePath(pathname);
   const publicPaths = ["/", "/resources", "/contact"];
-  const isPublic = publicPaths.includes(pathname);
+  const isDashboardPublic = relativePath === "/dashboard" && !requireAuth;
+  const isPublic = publicPaths.includes(relativePath) || isDashboardPublic;
 
   const bodyClass = cn(
     "min-h-screen",
@@ -27,10 +32,10 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
   useEffect(() => {
     // Replace this with your actual authentication logic
 
-    if (!isLoading && !isAuthenticated && !isPublic) {
+    if (!isLoading && !isAuthenticated && !isPublic && !loading) {
       router.push("/");
     }
-  }, [isAuthenticated, isLoading, isPublic, router]);
+  }, [isAuthenticated, isLoading, isPublic, loading, router]);
 
   if (isLoading) {
     return <div className={bodyClass}>...loading </div>;

--- a/app/tcoin/wallet/path.test.ts
+++ b/app/tcoin/wallet/path.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { walletRelativePath } from './path'
+
+describe('walletRelativePath', () => {
+  it('removes wallet base path', () => {
+    expect(walletRelativePath('/tcoin/wallet/dashboard')).toBe('/dashboard')
+    expect(walletRelativePath('/tcoin/wallet/dashboard/')).toBe('/dashboard')
+    expect(walletRelativePath('/tcoin/wallet')).toBe('/')
+    expect(walletRelativePath('/tcoin/wallet/resources')).toBe('/resources')
+    expect(walletRelativePath('/dashboard/')).toBe('/dashboard')
+  })
+})
+

--- a/app/tcoin/wallet/path.ts
+++ b/app/tcoin/wallet/path.ts
@@ -1,0 +1,5 @@
+export function walletRelativePath(pathname: string): string {
+  const path = pathname.replace(/^\/tcoin\/wallet/, "") || "/"
+  return path !== "/" ? path.replace(/\/$/, "") : path
+}
+

--- a/app/tcoin/wallet/useRequireAuthOnDashboard.test.ts
+++ b/app/tcoin/wallet/useRequireAuthOnDashboard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRequireAuth } from './useRequireAuthOnDashboard'
+
+describe('shouldRequireAuth', () => {
+  it('returns true for truthy values', () => {
+    expect(shouldRequireAuth('true')).toBe(true)
+    expect(shouldRequireAuth('TRUE')).toBe(true)
+    expect(shouldRequireAuth(1)).toBe(true)
+    expect(shouldRequireAuth('1')).toBe(true)
+    expect(shouldRequireAuth(true)).toBe(true)
+  })
+
+  it('returns false for other values', () => {
+    expect(shouldRequireAuth('false')).toBe(false)
+    expect(shouldRequireAuth(false)).toBe(false)
+    expect(shouldRequireAuth(0)).toBe(false)
+    expect(shouldRequireAuth('0')).toBe(false)
+    expect(shouldRequireAuth(undefined)).toBe(false)
+  })
+})

--- a/app/tcoin/wallet/useRequireAuthOnDashboard.ts
+++ b/app/tcoin/wallet/useRequireAuthOnDashboard.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+export function shouldRequireAuth(value: unknown): boolean {
+  return value === true || value === 'true' || value === 'TRUE' || value === 1 || value === '1'
+}
+
+export default function useRequireAuthOnDashboard() {
+  const [requireAuth, setRequireAuth] = useState(true)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchFlag = async () => {
+      const { createClient } = await import('@shared/lib/supabase/client')
+      const supabase = createClient()
+      const { data, error } = await supabase
+        .from('control_variables')
+        .select('value')
+        .eq('variable', 'require_authenticated_on_dashboard')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle()
+
+      if (!error && data) {
+        setRequireAuth(shouldRequireAuth(data.value))
+      }
+      setLoading(false)
+    }
+
+    fetchFlag()
+  }, [])
+
+  return { requireAuth, loading }
+}


### PR DESCRIPTION
## Summary
- read latest `require_authenticated_on_dashboard` record so dashboard stays public when flag is false
- normalise wallet-relative paths to strip trailing slashes
- document control-variable behaviour in functional and technical specs

## Testing
- `pnpm lint`
- `pnpm dlx vitest run app/tcoin/wallet/useRequireAuthOnDashboard.test.ts app/tcoin/wallet/path.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c05fafb4588324914723c6cf9f545c