### PR TITLE
fix(wallet): stop dashboard redirect loop

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.42
+- Stopped a self-redirect on the wallet dashboard that caused client errors and added tests for profile redirection.
+
 ## v0.41
 - Closed modals with the Escape key and confirmed missing request amounts with a follow-up modal.
 - Restored camera access for QR payments and ensured top ups display their modal again.

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -71,3 +71,4 @@
 - Theme background variables are now pure white for light mode and pure black for dark mode, and the landing, resources and contact main panels force black backgrounds when dark mode is active.
 - Public page wrappers now use `bg-background` so panels take their colour from the theme variable instead of hard-coded white.
 - Internal links use root-relative URLs and rewrites map them to the wallet app, eliminating `/tcoin/wallet` from page paths.
+- Dashboard route redirects users without a Cubid full name to `/welcome` to complete setup and avoid client-side errors.

--- a/app/tcoin/wallet/dashboard/page.test.tsx
+++ b/app/tcoin/wallet/dashboard/page.test.tsx
@@ -1,0 +1,51 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+const replaceMock = vi.fn();
+
+vi.mock("@shared/api/hooks/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: replaceMock }),
+}));
+
+vi.mock("./screens/WalletScreen", () => ({
+  WalletScreen: () => <div data-testid="wallet" />, 
+}));
+
+import Dashboard from "./page";
+import { useAuth } from "@shared/api/hooks/useAuth";
+
+const mockedUseAuth = useAuth as Mock;
+
+beforeEach(() => {
+  replaceMock.mockReset();
+  mockedUseAuth.mockReset();
+});
+
+describe("Dashboard page redirection", () => {
+  it("redirects to /welcome when profile is incomplete", () => {
+    mockedUseAuth.mockReturnValue({
+      userData: { cubidData: {} },
+      error: null,
+      isLoadingUser: false,
+    });
+    render(<Dashboard />);
+    expect(replaceMock).toHaveBeenCalledWith("/welcome");
+  });
+
+  it("does not redirect when profile is complete", () => {
+    mockedUseAuth.mockReturnValue({
+      userData: { cubidData: { full_name: "Jane" } },
+      error: null,
+      isLoadingUser: false,
+    });
+    render(<Dashboard />);
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/tcoin/wallet/dashboard/page.tsx
+++ b/app/tcoin/wallet/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
+import React, { useEffect, useMemo } from "react";
 import { useAuth } from "@shared/api/hooks/useAuth";
-import { useEffect, useMemo } from "react";
 import { WalletScreen } from "./screens/WalletScreen";
 import { useRouter } from "next/navigation";
 
@@ -8,7 +8,7 @@ export default function Dashboard() {
   const { userData, error, isLoadingUser } = useAuth();
 
   const mainClass = "p-4 sm:p-8 bg-background text-foreground min-h-screen";
-  const router = useRouter()
+  const router = useRouter();
 
   const screenContent = useMemo(() => {
     if (isLoadingUser || error) return null;
@@ -21,12 +21,13 @@ export default function Dashboard() {
       default:
         return <WalletScreen />;
     }
-  }, [userData]);
+  }, [error, isLoadingUser, userData]);
+
   useEffect(() => {
-    if (Boolean(userData?.cubidData?.full_name)) {
-      router.replace('/dashboard')
+    if (!userData?.cubidData?.full_name) {
+      router.replace("/welcome");
     }
-  }, [userData, router])
+  }, [userData, router]);
 
   if (error) {
     return <div className={mainClass}>Error loading data: {error.message}</div>;


### PR DESCRIPTION
## Summary
- prevent dashboard page from self-redirecting and send incomplete profiles to `/welcome`
- add tests for dashboard redirect logic
- record session notes and spec update

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Attempted import error: 'TabTrigger' is not exported from '@shared/components/ui/Tabs')*


------
https://chatgpt.com/codex/tasks/task_e_68c1fa24f0c88324b0867a80b9c2e134