### PR TITLE
feat(wallet): enhance ecosystem SEO

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.62
+- Secured Ecosystem links with `rel="noopener noreferrer"` and added tests.
+
 ## v0.61
 - Added public Ecosystem page listing related projects and linked it from resources and the landing footer for SEO.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -38,7 +38,7 @@
 - Modal provider listens for the Escape key to dismiss any open modal.
 - QR scanning modal requests camera access via `navigator.mediaDevices.getUserMedia`.
 - Demurrage timers for token decay embedded in wallet logic.
-- Public `/ecosystem` page lists allied projects and is linked from resources and the landing footer for SEO.
+- Public `/ecosystem` page lists allied projects, links from resources and the landing footer for SEO, and opens external links in new tabs with `rel="noopener noreferrer"`.
 - Send tab converts string token balances to numbers before performing arithmetic.
 - Token balances from Web3 are returned as strings; dashboard components parse them to numbers before applying arithmetic or `toFixed`.
 - Sign-in modal shows a spam-folder notice with an inline "Resend Code" link instead of a button.

--- a/app/tcoin/wallet/ecosystem/page.test.tsx
+++ b/app/tcoin/wallet/ecosystem/page.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import EcosystemPage from "./page";
+import EcosystemPage, { metadata } from "./page";
 
 vi.mock("next/link", () => ({ default: (props: any) => <a {...props} /> }));
 
@@ -11,5 +11,36 @@ describe("EcosystemPage", () => {
     const { getAllByRole } = render(<EcosystemPage />);
     const headings = getAllByRole("heading", { level: 2 });
     expect(headings).toHaveLength(16);
+  });
+
+  it("opens links safely in new tabs", () => {
+    const { getAllByRole } = render(<EcosystemPage />);
+    const links = getAllByRole("link");
+    links.forEach((link) => {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    });
+  });
+
+  it("exports SEO metadata", () => {
+    expect(metadata).toMatchObject({
+      title: "TCOIN Ecosystem",
+      description:
+        "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+      openGraph: {
+        title: "TCOIN Ecosystem",
+        description:
+          "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+        type: "website",
+        url: "https://tcoin.me/ecosystem",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: "TCOIN Ecosystem",
+        description:
+          "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+      },
+      alternates: { canonical: "https://tcoin.me/ecosystem" },
+    });
   });
 });

--- a/app/tcoin/wallet/ecosystem/page.tsx
+++ b/app/tcoin/wallet/ecosystem/page.tsx
@@ -1,7 +1,30 @@
-'use client'
-
+import type { Metadata } from "next";
 import React from "react";
-import Link from "next/link"
+import Link from "next/link";
+
+const baseUrl = "https://tcoin.me";
+
+export const metadata: Metadata = {
+  title: "TCOIN Ecosystem",
+  description:
+    "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+  openGraph: {
+    title: "TCOIN Ecosystem",
+    description:
+      "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+    type: "website",
+    url: `${baseUrl}/ecosystem`,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "TCOIN Ecosystem",
+    description:
+      "Explore our interconnected projects across identity, payments, coordination, and regenerative economies.",
+  },
+  alternates: {
+    canonical: `${baseUrl}/ecosystem`,
+  },
+};
 
 export default function EcosystemPage() {
   const sites = [
@@ -36,7 +59,12 @@ export default function EcosystemPage() {
           {sites.map((site) => (
             <div key={site.url} className="p-6 bg-white dark:bg-slate-800 rounded-2xl shadow hover:shadow-lg transition">
               <h2 className="text-2xl font-semibold mb-2">
-                <Link href={site.url} target="_blank" className="hover:underline">
+                <Link
+                  href={site.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:underline"
+                >
                   {site.name}
                 </Link>
               </h2>

--- a/app/tcoin/wallet/sitemap.test.ts
+++ b/app/tcoin/wallet/sitemap.test.ts
@@ -1,0 +1,14 @@
+/** @vitest-environment node */
+import sitemap from "./sitemap";
+import { describe, expect, it } from "vitest";
+
+describe("sitemap", () => {
+  it("includes ecosystem page", () => {
+    const entries = sitemap();
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: "https://tcoin.me/ecosystem" }),
+      ]),
+    );
+  });
+});

--- a/app/tcoin/wallet/sitemap.ts
+++ b/app/tcoin/wallet/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+const baseUrl = "https://tcoin.me";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: new Date(),
+    },
+    {
+      url: `${baseUrl}/ecosystem`,
+      lastModified: new Date(),
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add metadata for Ecosystem page with canonical, OpenGraph, and Twitter tags
- include wallet routes in sitemap including ecosystem
- test SEO metadata and sitemap entries
- prevent reverse tabnabbing on Ecosystem links

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c78f7ffe6c8324a5831a094f0e5d2c