### PR TITLE
fix: refresh session state after sign-in

### DIFF
--- a/app/tcoin/wallet/ContentLayout.tsx
+++ b/app/tcoin/wallet/ContentLayout.tsx
@@ -40,9 +40,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
     <section className={bodyClass}>
       {!isPublic && <Navbar title="TCOIN" />}
       <div className={cn(!isPublic && "flex-grow flex flex-col pt-16 bg-background text-foreground")}>{children}</div>
-      {!isPublic && (
-        <ToastContainer autoClose={3000} transition={Flip} theme="colored" />
-      )}
+      <ToastContainer autoClose={3000} transition={Flip} theme="colored" />
     </section>
   );
 }

--- a/app/tcoin/wallet/components/dashboard/ContactsTab.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/ContactsTab.test.tsx
@@ -85,4 +85,31 @@ describe("ContactsTab", () => {
       expect.objectContaining({ id: 1, full_name: "Alice" })
     );
   });
+
+  it("notifies when contacts are resolved and seeds initial contacts", async () => {
+    const onContactsResolved = vi.fn();
+    const seed = [
+      {
+        id: 5,
+        full_name: "Zara",
+        username: "zara",
+        profile_image_url: null,
+        wallet_address: null,
+        state: "accepted",
+        last_interaction: "2024-01-04T00:00:00.000Z",
+      },
+    ];
+
+    render(
+      <ContactsTab
+        onSend={vi.fn()}
+        initialContacts={seed as any}
+        onContactsResolved={onContactsResolved}
+      />
+    );
+
+    expect(await screen.findByText("Zara")).toBeTruthy();
+
+    await waitFor(() => expect(onContactsResolved).toHaveBeenCalled());
+  });
 });

--- a/app/tcoin/wallet/components/dashboard/ContactsTab.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/ContactsTab.test.tsx
@@ -1,0 +1,88 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { ContactsTab } from "./ContactsTab";
+
+const fetchContactsForOwnerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@shared/api/hooks/useAuth", () => ({
+  useAuth: () => ({ userData: { cubidData: { id: 1 } } }),
+}));
+
+vi.mock("@shared/api/services/supabaseService", () => ({
+  fetchContactsForOwner: fetchContactsForOwnerMock,
+}));
+
+describe("ContactsTab", () => {
+  beforeEach(() => {
+    fetchContactsForOwnerMock.mockReset();
+    fetchContactsForOwnerMock.mockResolvedValue([
+      {
+        id: 1,
+        full_name: "Alice",
+        username: "alice",
+        profile_image_url: null,
+        wallet_address: "0x1111",
+        state: "accepted",
+        last_interaction: "2024-01-02T00:00:00.000Z",
+      },
+      {
+        id: 2,
+        full_name: "Bob",
+        username: "bob",
+        profile_image_url: null,
+        wallet_address: "0x2222",
+        state: "accepted",
+        last_interaction: "2024-01-03T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("sorts alphabetically by default and toggles to recents", async () => {
+    render(<ContactsTab onSend={vi.fn()} onRequest={vi.fn()} />);
+
+    const items = await screen.findAllByRole("listitem");
+    expect(items[0].textContent).toContain("Alice");
+
+    fireEvent.click(screen.getByRole("button", { name: /Recents/i }));
+
+    const resorted = await screen.findAllByRole("listitem");
+    expect(resorted[0].textContent).toContain("Bob");
+  });
+
+  it("invokes callbacks for Send To and Request From", async () => {
+    const onSend = vi.fn();
+    const onRequest = vi.fn();
+    render(<ContactsTab onSend={onSend} onRequest={onRequest} />);
+
+    await screen.findByText("Alice");
+
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems.length).toBe(2);
+
+    const sendToAliceButton = await screen.findByRole("button", {
+      name: /Send to Alice/i,
+    });
+
+    fireEvent.click(sendToAliceButton);
+    await waitFor(() => expect(onSend).toHaveBeenCalled());
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, full_name: "Alice" })
+    );
+
+    const requestFromAliceButton = await screen.findByRole("button", {
+      name: /Request from Alice/i,
+    });
+
+    fireEvent.click(requestFromAliceButton);
+    await waitFor(() => expect(onRequest).toHaveBeenCalled());
+    expect(onRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, full_name: "Alice" })
+    );
+  });
+});

--- a/app/tcoin/wallet/components/dashboard/ContactsTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/ContactsTab.tsx
@@ -1,18 +1,36 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
+import { Avatar, AvatarFallback, AvatarImage } from "@shared/components/ui/Avatar";
 import { useAuth } from "@shared/api/hooks/useAuth";
-import { fetchContactsForOwner, type ContactRecord } from "@shared/api/services/supabaseService";
+import {
+  fetchContactsForOwner,
+  type ContactRecord,
+} from "@shared/api/services/supabaseService";
 import { Hypodata } from "./types";
+
+type SortOrder = "alphabetical" | "recents";
 
 interface ContactsTabProps {
   onSend: (contact: Hypodata) => void;
+  onRequest?: (contact: Hypodata) => void;
 }
 
-export function ContactsTab({ onSend }: ContactsTabProps) {
+const formatName = (contact: ContactRecord) =>
+  contact.full_name?.trim() || contact.username?.trim() || "Unknown";
+
+const getInitials = (contact: ContactRecord) => {
+  const name = formatName(contact);
+  const parts = name.split(" ");
+  if (parts.length === 1) return parts[0]?.[0]?.toUpperCase() ?? "?";
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+};
+
+export function ContactsTab({ onSend, onRequest }: ContactsTabProps) {
   const { userData } = useAuth();
   const [contacts, setContacts] = useState<ContactRecord[]>([]);
   const [search, setSearch] = useState("");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("alphabetical");
 
   useEffect(() => {
     let isMounted = true;
@@ -41,45 +59,107 @@ export function ContactsTab({ onSend }: ContactsTabProps) {
     };
   }, [userData?.cubidData?.id]);
 
-  const filtered = contacts.filter((contact) => {
-    const name = contact.full_name?.toLowerCase() ?? "";
-    const username = contact.username?.toLowerCase() ?? "";
-    const query = search.toLowerCase();
-    return name.includes(query) || username.includes(query);
-  });
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const base = contacts.filter((contact) => {
+      if (!query) return true;
+      const name = contact.full_name?.toLowerCase() ?? "";
+      const username = contact.username?.toLowerCase() ?? "";
+      return name.includes(query) || username.includes(query);
+    });
+
+    if (sortOrder === "alphabetical") {
+      return [...base].sort((a, b) => {
+        const nameA = formatName(a).toLowerCase();
+        const nameB = formatName(b).toLowerCase();
+        if (nameA < nameB) return -1;
+        if (nameA > nameB) return 1;
+        return 0;
+      });
+    }
+
+    return [...base].sort((a, b) => {
+      const getTimestamp = (contact: ContactRecord) => {
+        const raw = contact.last_interaction;
+        const parsed = raw ? Date.parse(raw) : NaN;
+        return Number.isNaN(parsed) ? -Infinity : parsed;
+      };
+      return getTimestamp(b) - getTimestamp(a);
+    });
+  }, [contacts, search, sortOrder]);
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-between items-center">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-xl font-semibold">Contacts</h1>
-        <Button variant="outline" size="sm">Add Contact</Button>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant={sortOrder === "alphabetical" ? "default" : "outline"}
+            onClick={() => setSortOrder("alphabetical")}
+          >
+            Alphabetical
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant={sortOrder === "recents" ? "default" : "outline"}
+            onClick={() => setSortOrder("recents")}
+          >
+            Recents
+          </Button>
+        </div>
       </div>
       <Input
         placeholder="Search contacts..."
         value={search}
         onChange={(e) => setSearch(e.target.value)}
       />
-      <ul className="space-y-2">
+      <ul className="space-y-3">
         {filtered.map((contact) => (
           <li
             key={contact.id}
-            className="flex items-center justify-between rounded-md border p-3"
+            className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-border bg-card/40 p-3"
           >
-            <div className="flex flex-col">
-              <span className="font-medium">{contact.full_name ?? "Unknown"}</span>
-              {contact.username && (
-                <span className="text-sm text-muted-foreground">@{contact.username}</span>
-              )}
-              {contact.wallet_address && (
-                <span className="text-sm text-muted-foreground">
-                  {contact.wallet_address.slice(0, 6)}...
-                  {contact.wallet_address.slice(-4)}
-                </span>
+            <div className="flex items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarImage src={contact.profile_image_url ?? undefined} alt={formatName(contact)} />
+                <AvatarFallback>{getInitials(contact)}</AvatarFallback>
+              </Avatar>
+              <div className="flex flex-col">
+                <span className="font-medium">{formatName(contact)}</span>
+                {contact.username && (
+                  <span className="text-sm text-muted-foreground">@{contact.username}</span>
+                )}
+                {contact.wallet_address && (
+                  <span className="text-xs text-muted-foreground">
+                    {contact.wallet_address.slice(0, 6)}…
+                    {contact.wallet_address.slice(-4)}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() => onSend(contact)}
+                aria-label={`Send to ${formatName(contact)}`}
+              >
+                Send To
+              </Button>
+              {onRequest && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onRequest(contact)}
+                  aria-label={`Request from ${formatName(contact)}`}
+                >
+                  Request From
+                </Button>
               )}
             </div>
-            <Button size="sm" onClick={() => onSend(contact)}>
-              Select
-            </Button>
           </li>
         ))}
         {filtered.length === 0 && <p>No contacts found.</p>}

--- a/app/tcoin/wallet/components/dashboard/ContactsTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/ContactsTab.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { LuSend } from "react-icons/lu";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { useAuth } from "@shared/api/hooks/useAuth";
@@ -65,11 +64,8 @@ export function ContactsTab({ onSend }: ContactsTabProps) {
                 </span>
               )}
             </div>
-            <Button
-              size="sm"
-              onClick={() => onSend(contact)}
-            >
-              <LuSend className="mr-2 h-4 w-4" /> Send
+            <Button size="sm" onClick={() => onSend(contact)}>
+              Select
             </Button>
           </li>
         ))}

--- a/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
@@ -73,17 +73,19 @@ export function ReceiveCard({
     });
   };
 
+  const rawAmount = qrTcoinAmount?.trim() ?? "";
+  const cleanedAmount = rawAmount.replace(/\s*TCOIN\s*$/i, "").trim();
+  const hasAmount = cleanedAmount !== "" && cleanedAmount !== "0.00";
+  const qrCaption = hasAmount
+    ? `Receive ${cleanedAmount} ${tokenLabel.toUpperCase()}`
+    : `Receive any amount ${tokenLabel.toUpperCase()}`;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Receive</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4 mt-[-10px]">
-        <p>
-          {Boolean(qrTcoinAmount) && qrTcoinAmount !== "0.00 TCOIN"
-            ? `Receive ${qrTcoinAmount}`
-            : "Receive any amount"}
-        </p>
         <div
           className={cn(
             "relative flex flex-col items-center justify-center rounded-xl transform transition duration-500 hover:scale-105",
@@ -91,12 +93,17 @@ export function ReceiveCard({
           )}
         >
           {qrCodeData ? (
-            <QRCode
-              value={qrCodeData}
-              size={250}
-              bgColor={qrBgColor ?? "transparent"}
-              fgColor={qrFgColor ?? (isDarkMode ? "#fff" : "#000")}
-            />
+            <>
+              <p className="mb-3 text-center text-base font-semibold text-gray-900">
+                {qrCaption}
+              </p>
+              <QRCode
+                value={qrCodeData}
+                size={250}
+                bgColor={qrBgColor ?? "transparent"}
+                fgColor={qrFgColor ?? (isDarkMode ? "#fff" : "#000")}
+              />
+            </>
           ) : (
             <p className="text-white">Loading QR Code...</p>
           )}

--- a/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
@@ -11,6 +11,7 @@ import { cn } from "@shared/utils/classnames";
 import { ContactSelectModal, ShareQrModal } from "@tcoin/wallet/components/modals";
 import { Avatar, AvatarFallback, AvatarImage } from "@shared/components/ui/Avatar";
 import { Hypodata } from "./types";
+import type { ContactRecord } from "@shared/api/services/supabaseService";
 
 export function ReceiveCard({
   qrCodeData,
@@ -42,6 +43,8 @@ export function ReceiveCard({
   tokenLabel?: string;
   requestContact?: Hypodata | null;
   onClearRequestContact?: () => void;
+  contacts?: ContactRecord[];
+  onSelectRequestContact?: (contact: Hypodata) => void;
 }) {
   const { isDarkMode } = useDarkMode();
   const { ...rest } = useTokenBalance(senderWallet);
@@ -72,6 +75,8 @@ export function ReceiveCard({
           amount={qrTcoinAmount}
           method="Request"
           defaultContactId={requestContact?.id}
+          prefetchedContacts={contacts}
+          onSelectContact={(contact) => onSelectRequestContact?.(contact)}
         />
       ),
       title: "Request from Contact",
@@ -155,8 +160,11 @@ export function ReceiveCard({
                   </AvatarFallback>
                 </Avatar>
                 <div>
+                  <p className="text-xs font-semibold uppercase text-muted-foreground">
+                    Request From:
+                  </p>
                   <p className="text-sm font-medium">
-                    Request From {formatContactName(requestContact)}
+                    {formatContactName(requestContact)}
                   </p>
                   {requestContact.username && (
                     <p className="text-xs text-muted-foreground">

--- a/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
@@ -62,7 +62,6 @@ export function ReceiveCard({
     openModal({
       content: (
         <ContactSelectModal
-          setToSendData={handleQrTcoinChange}
           closeModal={closeModal}
           amount={qrTcoinAmount}
           method="Request"

--- a/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import QRCode from "react-qr-code";
-import { LuShare2, LuUsers } from "react-icons/lu";
+import { LuShare2, LuUsers, LuX } from "react-icons/lu";
 import { Button } from "@shared/components/ui/Button";
 import { Card, CardContent, CardHeader, CardTitle } from "@shared/components/ui/Card";
 import { Input } from "@shared/components/ui/Input";
@@ -9,6 +9,8 @@ import useDarkMode from "@shared/hooks/useDarkMode";
 import { useTokenBalance } from "@shared/hooks/useTokenBalance";
 import { cn } from "@shared/utils/classnames";
 import { ContactSelectModal, ShareQrModal } from "@tcoin/wallet/components/modals";
+import { Avatar, AvatarFallback, AvatarImage } from "@shared/components/ui/Avatar";
+import { Hypodata } from "./types";
 
 export function ReceiveCard({
   qrCodeData,
@@ -23,6 +25,8 @@ export function ReceiveCard({
   qrFgColor,
   qrWrapperClassName,
   tokenLabel = "Tcoin",
+  requestContact = null,
+  onClearRequestContact,
 }: {
   qrCodeData: string;
   qrTcoinAmount: string;
@@ -36,6 +40,8 @@ export function ReceiveCard({
   qrFgColor?: string;
   qrWrapperClassName?: string;
   tokenLabel?: string;
+  requestContact?: Hypodata | null;
+  onClearRequestContact?: () => void;
 }) {
   const { isDarkMode } = useDarkMode();
   const { ...rest } = useTokenBalance(senderWallet);
@@ -65,6 +71,7 @@ export function ReceiveCard({
           closeModal={closeModal}
           amount={qrTcoinAmount}
           method="Request"
+          defaultContactId={requestContact?.id}
         />
       ),
       title: "Request from Contact",
@@ -78,6 +85,9 @@ export function ReceiveCard({
   const qrCaption = hasAmount
     ? `Receive ${cleanedAmount} ${tokenLabel.toUpperCase()}`
     : `Receive any amount ${tokenLabel.toUpperCase()}`;
+
+  const formatContactName = (contact: Hypodata) =>
+    contact.full_name?.trim() || contact.username?.trim() || "Unknown";
 
   return (
     <Card>
@@ -131,6 +141,44 @@ export function ReceiveCard({
             placeholder="Enter CAD amount"
           />
         </div>
+        {requestContact && (
+          <div className="rounded-2xl border border-border bg-background/70 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Avatar className="h-11 w-11">
+                  <AvatarImage
+                    src={requestContact.profile_image_url ?? undefined}
+                    alt={formatContactName(requestContact)}
+                  />
+                  <AvatarFallback>
+                    {formatContactName(requestContact).charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">
+                    Request From {formatContactName(requestContact)}
+                  </p>
+                  {requestContact.username && (
+                    <p className="text-xs text-muted-foreground">
+                      @{requestContact.username}
+                    </p>
+                  )}
+                </div>
+              </div>
+              {onClearRequestContact && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={onClearRequestContact}
+                  aria-label="Clear request contact"
+                >
+                  <LuX className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
         <div className="flex flex-col gap-4 sm:flex-row">
           <Button className="flex-1" onClick={handleRequestClick}>
             <LuUsers className="mr-2 h-4 w-4" /> Request from Contact

--- a/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
@@ -59,19 +59,21 @@ export function ReceiveTab() {
   };
 
   return (
-    <ReceiveCard
-      qrCodeData={qrCodeData}
-      qrTcoinAmount={qrTcoinAmount}
-      qrCadAmount={qrCadAmount}
-      handleQrTcoinChange={handleQrTcoinChange}
-      handleQrCadChange={handleQrCadChange}
-      senderWallet={userData?.cubidData?.wallet_address || ""}
-      handleQrTcoinBlur={handleQrTcoinBlur}
-      handleQrCadBlur={handleQrCadBlur}
-      tokenLabel="TCOIN"
-      qrBgColor="#fff"
-      qrFgColor="#000"
-      qrWrapperClassName="bg-white p-1"
-    />
+    <div className="lg:px-[25vw]">
+      <ReceiveCard
+        qrCodeData={qrCodeData}
+        qrTcoinAmount={qrTcoinAmount}
+        qrCadAmount={qrCadAmount}
+        handleQrTcoinChange={handleQrTcoinChange}
+        handleQrCadChange={handleQrCadChange}
+        senderWallet={userData?.cubidData?.wallet_address || ""}
+        handleQrTcoinBlur={handleQrTcoinBlur}
+        handleQrCadBlur={handleQrCadBlur}
+        tokenLabel="TCOIN"
+        qrBgColor="#fff"
+        qrFgColor="#000"
+        qrWrapperClassName="bg-white p-1"
+      />
+    </div>
   );
 }

--- a/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from "react";
 import { useAuth } from "@shared/api/hooks/useAuth";
 import { useControlVariables } from "@shared/hooks/useGetLatestExchangeRate";
 import { ReceiveCard } from "./ReceiveCard";
+import { Hypodata } from "./types";
 
-export function ReceiveTab() {
+export function ReceiveTab({ contact }: { contact?: Hypodata | null }) {
   const { userData } = useAuth();
   const { exchangeRate } = useControlVariables();
 
@@ -12,6 +13,9 @@ export function ReceiveTab() {
   const [qrCodeData, setQrCodeData] = useState("");
   const [qrTcoinAmount, setQrTcoinAmount] = useState("");
   const [qrCadAmount, setQrCadAmount] = useState("");
+  const [requestContact, setRequestContact] = useState<Hypodata | null>(
+    contact ?? null
+  );
 
   useEffect(() => {
     if (!user_id) return;
@@ -58,6 +62,10 @@ export function ReceiveTab() {
     setQrTcoinAmount(formatNumber((num / exchangeRate).toString(), false));
   };
 
+  useEffect(() => {
+    setRequestContact(contact ?? null);
+  }, [contact]);
+
   return (
     <div className="lg:px-[25vw]">
       <ReceiveCard
@@ -73,6 +81,8 @@ export function ReceiveTab() {
         qrBgColor="#fff"
         qrFgColor="#000"
         qrWrapperClassName="bg-white p-1"
+        requestContact={requestContact}
+        onClearRequestContact={() => setRequestContact(null)}
       />
     </div>
   );

--- a/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/ReceiveTab.tsx
@@ -3,8 +3,15 @@ import { useAuth } from "@shared/api/hooks/useAuth";
 import { useControlVariables } from "@shared/hooks/useGetLatestExchangeRate";
 import { ReceiveCard } from "./ReceiveCard";
 import { Hypodata } from "./types";
+import type { ContactRecord } from "@shared/api/services/supabaseService";
 
-export function ReceiveTab({ contact }: { contact?: Hypodata | null }) {
+interface ReceiveTabProps {
+  contact?: Hypodata | null;
+  onContactChange?: (contact: Hypodata | null) => void;
+  contacts?: ContactRecord[];
+}
+
+export function ReceiveTab({ contact, onContactChange, contacts }: ReceiveTabProps) {
   const { userData } = useAuth();
   const { exchangeRate } = useControlVariables();
 
@@ -66,6 +73,11 @@ export function ReceiveTab({ contact }: { contact?: Hypodata | null }) {
     setRequestContact(contact ?? null);
   }, [contact]);
 
+  const handleRequestContactChange = (next: Hypodata | null) => {
+    setRequestContact(next);
+    onContactChange?.(next);
+  };
+
   return (
     <div className="lg:px-[25vw]">
       <ReceiveCard
@@ -82,7 +94,11 @@ export function ReceiveTab({ contact }: { contact?: Hypodata | null }) {
         qrFgColor="#000"
         qrWrapperClassName="bg-white p-1"
         requestContact={requestContact}
-        onClearRequestContact={() => setRequestContact(null)}
+        onClearRequestContact={() => handleRequestContactChange(null)}
+        contacts={contacts}
+        onSelectRequestContact={(selectedContact) =>
+          handleRequestContactChange(selectedContact)
+        }
       />
     </div>
   );

--- a/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
@@ -35,6 +35,8 @@ describe("SendCard", () => {
         cadAmount=""
         handleTcoinChange={noop as any}
         handleCadChange={noop as any}
+        handleTcoinBlur={noop}
+        handleCadBlur={noop}
         explorerLink={null}
         setExplorerLink={noop}
         setTcoin={noop}
@@ -58,6 +60,8 @@ describe("SendCard", () => {
         cadAmount=""
         handleTcoinChange={noop as any}
         handleCadChange={noop as any}
+        handleTcoinBlur={noop}
+        handleCadBlur={noop}
         explorerLink={null}
         setExplorerLink={noop}
         setTcoin={noop}
@@ -82,6 +86,8 @@ describe("SendCard", () => {
         cadAmount="2.3456"
         handleTcoinChange={noop as any}
         handleCadChange={noop as any}
+        handleTcoinBlur={noop}
+        handleCadBlur={noop}
         explorerLink={null}
         setExplorerLink={noop}
         setTcoin={noop}
@@ -91,6 +97,29 @@ describe("SendCard", () => {
         onUseMax={noop}
       />
     );
-    expect(screen.getByText("≈ 2.35 CAD")).toBeTruthy();
+    expect(screen.getByText("≈ $2.35 CAD")).toBeTruthy();
+  });
+
+  it("shows formatted primary amount when not focused", () => {
+    render(
+      <SendCard
+        toSendData={null}
+        setToSendData={noop}
+        tcoinAmount="1.2"
+        cadAmount=""
+        handleTcoinChange={noop as any}
+        handleCadChange={noop as any}
+        handleTcoinBlur={noop}
+        handleCadBlur={noop}
+        explorerLink={null}
+        setExplorerLink={noop}
+        setTcoin={noop}
+        setCad={noop}
+        sendMoney={vi.fn()}
+        userBalance={5}
+        onUseMax={noop}
+      />
+    );
+    expect(screen.getByDisplayValue("1.20 TCOIN")).toBeTruthy();
   });
 });

--- a/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import { SendCard } from "./SendCard";
+import { SendCard, calculateResponsiveFontSize } from "./SendCard";
 
 vi.mock("@shared/api/hooks/useAuth", () => ({
   useAuth: () => ({ userData: { cubidData: { id: 1 } } }),
@@ -46,7 +46,7 @@ describe("SendCard", () => {
         onUseMax={noop}
       />
     );
-    const button = screen.getByRole("button", { name: /send to contact/i }) as HTMLButtonElement;
+    const button = screen.getByRole("button", { name: /review payment/i }) as HTMLButtonElement;
     expect(button.disabled).toBe(true);
   });
 
@@ -121,5 +121,19 @@ describe("SendCard", () => {
       />
     );
     expect(screen.getByDisplayValue("1.20 TCOIN")).toBeTruthy();
+  });
+});
+
+describe("calculateResponsiveFontSize", () => {
+  it("returns the max size for short values", () => {
+    expect(calculateResponsiveFontSize("123")).toBe("min(4.50rem, 12vw)");
+  });
+
+  it("shrinks the size for longer values", () => {
+    expect(calculateResponsiveFontSize("123456789012")).toBe("min(3.50rem, 12vw)");
+  });
+
+  it("caps the size at the minimum for very long values", () => {
+    expect(calculateResponsiveFontSize("12345678901234567890")).toBe("min(2.75rem, 12vw)");
   });
 });

--- a/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.test.tsx
@@ -54,6 +54,10 @@ describe("SendCard", () => {
     expect(button.disabled).toBe(true);
   });
 
+  it("renders safely when contacts data is unavailable", () => {
+    expect(() => renderSendCard({ contacts: undefined as any })).not.toThrow();
+  });
+
   it("shows available balance and triggers onUseMax", () => {
     const onUseMax = vi.fn();
     renderSendCard({ userBalance: 5, onUseMax });

--- a/app/tcoin/wallet/components/dashboard/SendCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.tsx
@@ -85,7 +85,7 @@ interface SendCardProps {
   userBalance: number;
   onUseMax: () => void;
   locked?: boolean;
-  contacts: ContactRecord[];
+  contacts?: ContactRecord[];
   isFetchingContacts?: boolean;
 }
 
@@ -106,9 +106,10 @@ export function SendCard({
   userBalance,
   onUseMax,
   locked = false,
-  contacts,
+  contacts: rawContacts,
   isFetchingContacts = false,
 }: SendCardProps) {
+  const contacts = rawContacts ?? [];
   const [connections, setConnections] = useState<any>(null);
   const { userData } = useAuth();
   const { openModal, closeModal } = useModal();

--- a/app/tcoin/wallet/components/dashboard/SendCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { LuRefreshCcw, LuSend } from "react-icons/lu";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { LuRefreshCcw, LuSend, LuUserPlus, LuX } from "react-icons/lu";
 import { toast } from "react-toastify";
 import { useAuth } from "@shared/api/hooks/useAuth";
 import { Button } from "@shared/components/ui/Button";
+import { Input } from "@shared/components/ui/Input";
+import { Avatar, AvatarFallback, AvatarImage } from "@shared/components/ui/Avatar";
 import { useModal } from "@shared/contexts/ModalContext";
 import { createClient } from "@shared/lib/supabase/client";
 import { insertSuccessNotification } from "@shared/utils/insertNotification";
+import { type ContactRecord } from "@shared/api/services/supabaseService";
 import { Hypodata } from "./types";
 
 const FONT_SIZE_MAX_REM = 4.5;
@@ -34,7 +37,10 @@ const formatTcoinDisplay = (value: string) => {
   if (!Number.isFinite(num)) {
     return `${trimmed} TCOIN`;
   }
-  return `${num.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} TCOIN`;
+  return `${num.toLocaleString("en-CA", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })} TCOIN`;
 };
 
 const formatCadDisplay = (value: string) => {
@@ -44,7 +50,22 @@ const formatCadDisplay = (value: string) => {
   if (!Number.isFinite(num)) {
     return `$${trimmed}`;
   }
-  return `$${num.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return `$${num.toLocaleString("en-CA", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+};
+
+const formatContactName = (contact: ContactRecord | Hypodata) =>
+  contact.full_name?.trim() || contact.username?.trim() || "Unknown";
+
+const getContactInitials = (contact: ContactRecord | Hypodata) => {
+  const name = formatContactName(contact);
+  const parts = name.split(" ");
+  if (parts.length === 1) {
+    return parts[0]?.[0]?.toUpperCase() ?? "?";
+  }
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
 };
 
 interface SendCardProps {
@@ -59,11 +80,13 @@ interface SendCardProps {
   handleCadBlur: () => void;
   explorerLink: string | null;
   setExplorerLink: (link: string | null) => void;
-  setTcoin: any;
-  setCad: any;
+  setTcoin: (value: string) => void;
+  setCad: (value: string) => void;
   userBalance: number;
   onUseMax: () => void;
   locked?: boolean;
+  contacts: ContactRecord[];
+  isFetchingContacts?: boolean;
 }
 
 export function SendCard({
@@ -83,10 +106,20 @@ export function SendCard({
   userBalance,
   onUseMax,
   locked = false,
+  contacts,
+  isFetchingContacts = false,
 }: SendCardProps) {
   const [connections, setConnections] = useState<any>(null);
   const { userData } = useAuth();
   const { openModal, closeModal } = useModal();
+  const [isCadInput, setIsCadInput] = useState(false);
+  const [isTcoinFocused, setIsTcoinFocused] = useState(false);
+  const [isCadFocused, setIsCadFocused] = useState(false);
+  const [recipientQuery, setRecipientQuery] = useState("");
+  const [showAllContacts, setShowAllContacts] = useState(false);
+  const suggestionsRef = useRef<HTMLDivElement | null>(null);
+  const recipientInputRef = useRef<HTMLInputElement | null>(null);
+  const amountInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     if (!toSendData?.id || !userData?.cubidData?.id) return;
@@ -110,6 +143,13 @@ export function SendCard({
     fetchConnections();
   }, [toSendData?.id, userData?.cubidData?.id]);
 
+  useEffect(() => {
+    if (toSendData) {
+      setRecipientQuery("");
+      setShowAllContacts(false);
+    }
+  }, [toSendData]);
+
   const tcoinValue = parseFloat(tcoinAmount);
   const cadValue = parseFloat(cadAmount);
   const isValidAmount =
@@ -119,11 +159,10 @@ export function SendCard({
     cadValue > 0 &&
     tcoinValue <= userBalance;
 
-  const [isCadInput, setIsCadInput] = useState(false);
-  const [isTcoinFocused, setIsTcoinFocused] = useState(false);
-  const [isCadFocused, setIsCadFocused] = useState(false);
-  const amountLocked = locked &&
-    ((isCadInput ? cadAmount : tcoinAmount) !== "0" && (isCadInput ? cadAmount : tcoinAmount) !== "");
+  const amountLocked =
+    locked &&
+    ((isCadInput ? cadAmount : tcoinAmount) !== "0" &&
+      (isCadInput ? cadAmount : tcoinAmount) !== "");
 
   const displayValue = useMemo(() => {
     if (isCadInput) {
@@ -132,40 +171,74 @@ export function SendCard({
     return isTcoinFocused ? tcoinAmount : formatTcoinDisplay(tcoinAmount);
   }, [isCadInput, isCadFocused, cadAmount, isTcoinFocused, tcoinAmount]);
 
-  const fontSize = useMemo(() => calculateResponsiveFontSize(displayValue), [displayValue]);
+  const fontSize = useMemo(
+    () => calculateResponsiveFontSize(displayValue),
+    [displayValue]
+  );
+
+  const suggestions = useMemo(() => {
+    const query = recipientQuery.trim().toLowerCase();
+    if (!query) {
+      return contacts;
+    }
+    return contacts.filter((contact) => {
+      const name = contact.full_name?.toLowerCase() ?? "";
+      const username = contact.username?.toLowerCase() ?? "";
+      return name.includes(query) || username.includes(query);
+    });
+  }, [contacts, recipientQuery]);
+
+  const shouldShowSuggestions =
+    !locked && !toSendData && (showAllContacts || recipientQuery.trim() !== "");
+
+  const handleSelectContact = (contact: ContactRecord) => {
+    setToSendData(contact);
+    setRecipientQuery("");
+    setShowAllContacts(false);
+  };
+
+  const clearRecipient = () => {
+    setToSendData(null);
+    setTcoin("");
+    setCad("");
+    setRecipientQuery("");
+    setShowAllContacts(false);
+  };
+
+  useEffect(() => {
+    if (!shouldShowSuggestions) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!suggestionsRef.current) return;
+      if (
+        event.target instanceof Node &&
+        suggestionsRef.current.contains(event.target)
+      ) {
+        return;
+      }
+      if (
+        recipientInputRef.current &&
+        event.target instanceof Node &&
+        recipientInputRef.current.contains(event.target)
+      ) {
+        return;
+      }
+      setShowAllContacts(false);
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [shouldShowSuggestions]);
 
   return (
-    <div className="space-y-4">
-      {toSendData && (
-        <div className="p-4 mt-4 bg-gray-800 rounded-lg shadow-lg border border-gray-700 relative">
-          <button
-            onClick={() => {
-              setToSendData(null);
-              setTcoin("");
-              setCad("");
-            }}
-            className="absolute top-2 right-2 text-gray-500 hover:text-gray-300"
-          >
-            &times;
-          </button>
-          <p className="text-lg font-bold mb-2">{toSendData.full_name ?? ""}</p>
-          <p className="text-sm text-gray-400 mb-2">@{toSendData.username ?? ""}</p>
-          {toSendData.profile_image_url && (
-            <img
-              src={toSendData.profile_image_url}
-              alt={toSendData.full_name ?? ""}
-              className="w-16 h-16 rounded-full object-cover"
-            />
-          )}
-        </div>
-      )}
-
-      <div className="mx-auto w-full max-w-2xl">
-        <div className="relative mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-4 rounded-3xl border border-border/60 bg-background/70 px-6 py-8 shadow-lg sm:px-10 sm:py-10 lg:max-w-lg min-h-[24rem] sm:min-h-[26rem]">
+    <div className="space-y-6">
+      <div className="mx-auto w-full max-w-xl">
+        <div className="relative mx-auto flex aspect-square w-full max-w-xl flex-col items-center justify-center gap-4 rounded-3xl border border-border/60 bg-background/70 p-6 shadow-lg sm:p-8">
           <div className="w-full text-center">
             {isCadInput ? (
               <input
-                className="w-full text-center font-bold bg-transparent focus:outline-none leading-tight"
+                ref={amountInputRef}
+                className="w-full bg-transparent text-center font-bold leading-tight focus:outline-none"
                 name="cad"
                 value={displayValue}
                 onChange={amountLocked ? undefined : handleCadChange}
@@ -175,12 +248,14 @@ export function SendCard({
                   handleCadBlur();
                 }}
                 readOnly={amountLocked}
-                placeholder="0"
+                placeholder="$0.00"
                 style={{ fontSize }}
+                aria-label="Amount in Canadian dollars"
               />
             ) : (
               <input
-                className="w-full text-center font-bold bg-transparent focus:outline-none leading-tight"
+                ref={amountInputRef}
+                className="w-full bg-transparent text-center font-bold leading-tight focus:outline-none"
                 name="tcoin"
                 value={displayValue}
                 onChange={amountLocked ? undefined : handleTcoinChange}
@@ -190,18 +265,19 @@ export function SendCard({
                   handleTcoinBlur();
                 }}
                 readOnly={amountLocked}
-                placeholder="0"
+                placeholder="0.00"
                 style={{ fontSize }}
+                aria-label="Amount in TCOIN"
               />
             )}
           </div>
-          <div className="flex w-full justify-end pr-6">
+          <div className="flex w-full justify-end pr-4">
             <Button
               type="button"
               variant="ghost"
               size="icon"
               aria-label="Toggle between TCOIN and CAD"
-              className="rounded-full border border-border/60 h-12 w-12 [&_svg]:h-6 [&_svg]:w-6"
+              className="h-12 w-12 rounded-full border border-border/60 [&_svg]:h-6 [&_svg]:w-6"
               onClick={() => {
                 if (isCadInput) {
                   handleCadBlur();
@@ -221,14 +297,141 @@ export function SendCard({
               ? `≈ ${formatTcoinDisplay(tcoinAmount) || "0.00 TCOIN"}`
               : `≈ ${formatCadDisplay(cadAmount) || "$0.00"} CAD`}
           </p>
-          <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center justify-center gap-2 text-xs text-muted-foreground">
             <span>Available: {userBalance.toFixed(4)}</span>
-            <Button variant="link" className="p-0 h-auto text-xs" onClick={onUseMax}>
+            <Button
+              variant="link"
+              className="h-auto p-0 text-xs"
+              onClick={onUseMax}
+            >
               Use Max
             </Button>
           </div>
         </div>
       </div>
+
+      <section className="rounded-3xl border border-border bg-card/70 p-6 shadow-sm">
+        <div className="flex items-center justify-between gap-4">
+          <h2 className="text-lg font-semibold">Send To</h2>
+          {toSendData && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={clearRecipient}
+              aria-label="Clear recipient"
+            >
+              <LuX className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+
+        {toSendData ? (
+          <div className="mt-4 flex items-center gap-4 rounded-2xl border border-border bg-background/70 p-4">
+            <Avatar className="h-12 w-12">
+              <AvatarImage
+                src={toSendData.profile_image_url ?? undefined}
+                alt={formatContactName(toSendData)}
+              />
+              <AvatarFallback>{getContactInitials(toSendData)}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1">
+              <p className="text-base font-medium">{formatContactName(toSendData)}</p>
+              {toSendData.username && (
+                <p className="text-sm text-muted-foreground">@{toSendData.username}</p>
+              )}
+              {toSendData.wallet_address && (
+                <p className="text-xs text-muted-foreground">
+                  {toSendData.wallet_address.slice(0, 6)}…
+                  {toSendData.wallet_address.slice(-4)}
+                </p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="mt-4 space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="flex-1">
+                <label className="sr-only" htmlFor="send-card-recipient">
+                  Search contacts
+                </label>
+                <Input
+                  id="send-card-recipient"
+                  ref={recipientInputRef}
+                  value={recipientQuery}
+                  onChange={(event) => {
+                    setRecipientQuery(event.target.value);
+                    if (event.target.value.trim() !== "") {
+                      setShowAllContacts(false);
+                    }
+                  }}
+                  placeholder="Type a name or username"
+                  disabled={locked}
+                  autoComplete="off"
+                />
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  if (locked) return;
+                  setShowAllContacts(true);
+                  setTimeout(() => recipientInputRef.current?.focus(), 0);
+                }}
+                disabled={locked || (!isFetchingContacts && contacts.length === 0)}
+              >
+                <LuUserPlus className="mr-2 h-4 w-4" /> Select Contact
+              </Button>
+            </div>
+            {isFetchingContacts && (
+              <p className="text-sm text-muted-foreground">Loading contacts…</p>
+            )}
+            {shouldShowSuggestions && (
+              <div
+                ref={suggestionsRef}
+                className="max-h-56 overflow-y-auto rounded-2xl border border-dashed border-border/60 bg-background/80 p-2"
+              >
+                {suggestions.length > 0 ? (
+                  <ul className="space-y-1" role="listbox">
+                    {suggestions.map((contact) => (
+                      <li key={contact.id}>
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-3 rounded-xl p-2 text-left hover:bg-muted"
+                          onClick={() => handleSelectContact(contact)}
+                        >
+                          <Avatar className="h-9 w-9">
+                            <AvatarImage
+                              src={contact.profile_image_url ?? undefined}
+                              alt={formatContactName(contact)}
+                            />
+                            <AvatarFallback>{getContactInitials(contact)}</AvatarFallback>
+                          </Avatar>
+                          <div className="flex-1">
+                            <p className="text-sm font-medium">{formatContactName(contact)}</p>
+                            {contact.username && (
+                              <p className="text-xs text-muted-foreground">@{contact.username}</p>
+                            )}
+                          </div>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="px-2 py-4 text-sm text-muted-foreground">
+                    No contacts found. Try a different search.
+                  </p>
+                )}
+              </div>
+            )}
+            {!isFetchingContacts && contacts.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                You do not have any contacts yet.
+              </p>
+            )}
+          </div>
+        )}
+      </section>
 
       <Button
         className="w-full"
@@ -257,17 +460,17 @@ export function SendCard({
           });
         }}
       >
-        <LuSend className="mr-2 h-4 w-4" /> Review Payment
+        <LuSend className="mr-2 h-4 w-4" /> Send...
       </Button>
 
       {explorerLink && (
-        <div className="p-4 bg-green-900/20 rounded-lg">
-          <div className="text-center space-y-4">
+        <div className="rounded-lg bg-green-900/20 p-4">
+          <div className="space-y-4 text-center">
             <>
               <h3 className="text-lg font-bold text-green-400">Success!</h3>
               <a
                 href={explorerLink}
-                className="text-blue-400 underline block"
+                className="block text-blue-400 underline"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -275,9 +478,9 @@ export function SendCard({
               </a>
             </>
             {!connections?.[0] && toSendData && (
-              <div className="pt-4 border-t border-gray-700">
+              <div className="border-t border-gray-700 pt-4">
                 <p>Add to Contacts?</p>
-                <div className="flex justify-center gap-4 mt-2">
+                <div className="mt-2 flex justify-center gap-4">
                   <Button
                     size="sm"
                     onClick={async () => {
@@ -364,7 +567,7 @@ function ConfirmTransactionModal({
   const formattedCad = formatCadDisplay(cadAmount) || "$0.00";
 
   return (
-    <div className="p-4 space-y-4">
+    <div className="space-y-4 p-4">
       <h3 className="text-lg font-bold">Confirm Transaction</h3>
       <div className="space-y-2">
         <p>Amount: {formattedTcoin} ({formattedCad} CAD)</p>
@@ -399,16 +602,7 @@ function ConfirmTransactionModal({
             }
           }}
         >
-          {isLoading ? (
-            <>
-              <span className="animate-spin inline-block w-4 h-4 border-2 border-t-2 border-white rounded-full mr-2"></span>
-              Sending...
-            </>
-          ) : (
-            <>
-              <LuSend className="mr-2 h-4 w-4" /> Send Now
-            </>
-          )}
+          Confirm
         </Button>
       </div>
     </div>

--- a/app/tcoin/wallet/components/dashboard/SendCard.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendCard.tsx
@@ -132,66 +132,71 @@ export function SendCard({
         </div>
       )}
 
-      <div className="space-y-2 text-center">
-        {isCadInput ? (
-          <input
-            className="w-full text-center text-7xl font-bold bg-transparent focus:outline-none"
-            name="cad"
-            value={isCadFocused ? cadAmount : formatCadDisplay(cadAmount)}
-            onChange={amountLocked ? undefined : handleCadChange}
-            onFocus={() => setIsCadFocused(true)}
-            onBlur={() => {
-              setIsCadFocused(false);
-              handleCadBlur();
-            }}
-            readOnly={amountLocked}
-            placeholder="0"
-          />
-        ) : (
-          <input
-            className="w-full text-center text-7xl font-bold bg-transparent focus:outline-none"
-            name="tcoin"
-            value={isTcoinFocused ? tcoinAmount : formatTcoinDisplay(tcoinAmount)}
-            onChange={amountLocked ? undefined : handleTcoinChange}
-            onFocus={() => setIsTcoinFocused(true)}
-            onBlur={() => {
-              setIsTcoinFocused(false);
-              handleTcoinBlur();
-            }}
-            readOnly={amountLocked}
-            placeholder="0"
-          />
-        )}
-        <div className="flex justify-end">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            aria-label="Toggle between TCOIN and CAD"
-            onClick={() => {
-              if (isCadInput) {
-                handleCadBlur();
-              } else {
-                handleTcoinBlur();
-              }
-              setIsCadInput((prev) => !prev);
-              setIsCadFocused(false);
-              setIsTcoinFocused(false);
-            }}
-          >
-            <LuRefreshCcw className="h-5 w-5" />
-          </Button>
-        </div>
-        <p className="text-sm text-muted-foreground text-right">
-          {isCadInput
-            ? `≈ ${formatTcoinDisplay(tcoinAmount) || "0.00 TCOIN"}`
-            : `≈ ${formatCadDisplay(cadAmount) || "$0.00"} CAD`}
-        </p>
-        <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
-          <span>Available: {userBalance.toFixed(4)}</span>
-          <Button variant="link" className="p-0 h-auto text-xs" onClick={onUseMax}>
-            Use Max
-          </Button>
+      <div className="mx-auto w-full max-w-2xl">
+        <div className="relative mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-4 rounded-3xl border border-border/60 bg-background/70 px-6 py-8 shadow-lg sm:px-10 sm:py-10 lg:max-w-lg min-h-[24rem] sm:min-h-[26rem]">
+          <div className="w-full text-center">
+            {isCadInput ? (
+              <input
+                className="w-full text-center text-7xl font-bold bg-transparent focus:outline-none"
+                name="cad"
+                value={isCadFocused ? cadAmount : formatCadDisplay(cadAmount)}
+                onChange={amountLocked ? undefined : handleCadChange}
+                onFocus={() => setIsCadFocused(true)}
+                onBlur={() => {
+                  setIsCadFocused(false);
+                  handleCadBlur();
+                }}
+                readOnly={amountLocked}
+                placeholder="0"
+              />
+            ) : (
+              <input
+                className="w-full text-center text-7xl font-bold bg-transparent focus:outline-none"
+                name="tcoin"
+                value={isTcoinFocused ? tcoinAmount : formatTcoinDisplay(tcoinAmount)}
+                onChange={amountLocked ? undefined : handleTcoinChange}
+                onFocus={() => setIsTcoinFocused(true)}
+                onBlur={() => {
+                  setIsTcoinFocused(false);
+                  handleTcoinBlur();
+                }}
+                readOnly={amountLocked}
+                placeholder="0"
+              />
+            )}
+          </div>
+          <div className="flex w-full justify-end pr-6">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label="Toggle between TCOIN and CAD"
+              className="rounded-full border border-border/60"
+              onClick={() => {
+                if (isCadInput) {
+                  handleCadBlur();
+                } else {
+                  handleTcoinBlur();
+                }
+                setIsCadInput((prev) => !prev);
+                setIsCadFocused(false);
+                setIsTcoinFocused(false);
+              }}
+            >
+              <LuRefreshCcw className="h-5 w-5" />
+            </Button>
+          </div>
+          <p className="text-sm text-muted-foreground text-center">
+            {isCadInput
+              ? `≈ ${formatTcoinDisplay(tcoinAmount) || "0.00 TCOIN"}`
+              : `≈ ${formatCadDisplay(cadAmount) || "$0.00"} CAD`}
+          </p>
+          <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+            <span>Available: {userBalance.toFixed(4)}</span>
+            <Button variant="link" className="p-0 h-auto text-xs" onClick={onUseMax}>
+              Use Max
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/app/tcoin/wallet/components/dashboard/SendTab.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendTab.test.tsx
@@ -104,6 +104,10 @@ describe("SendTab", () => {
     expect(screen.getByText(/select contact/i)).toBeTruthy();
     fireEvent.click(screen.getByText(/scan qr code/i));
     expect(openModal).toHaveBeenCalled();
+    fireEvent.click(screen.getByText(/select contact/i));
+    expect(openModal).toHaveBeenCalledTimes(2);
+    const modalArgs = openModal.mock.calls[1][0];
+    expect(modalArgs.title).toBe("Select Contact");
   });
 });
 

--- a/app/tcoin/wallet/components/dashboard/SendTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendTab.tsx
@@ -31,7 +31,6 @@ export function SendTab({ recipient }: SendTabProps) {
   const [cadAmount, setCadAmount] = useState("");
   const [explorerLink, setExplorerLink] = useState<string | null>(null);
   const [mode, setMode] = useState<"manual" | "qr" | "link">("manual");
-  const [showContacts, setShowContacts] = useState(false);
   const [payLink, setPayLink] = useState("");
   const { openModal, closeModal } = useModal();
 
@@ -189,7 +188,6 @@ export function SendTab({ recipient }: SendTabProps) {
 
   useEffect(() => {
     reset();
-    setShowContacts(false);
     if (mode === "qr") {
       openScanner();
       setMode("manual");
@@ -198,6 +196,20 @@ export function SendTab({ recipient }: SendTabProps) {
 
   const amountEntered =
     (parseFloat(tcoinAmount) || 0) > 0 || (parseFloat(cadAmount) || 0) > 0;
+
+  const openContactsModal = () => {
+    openModal({
+      title: "Select Contact",
+      content: (
+        <ContactsTab
+          onSend={(contact) => {
+            setToSendData(contact);
+            closeModal();
+          }}
+        />
+      ),
+    });
+  };
 
   return (
     <div className="space-y-4 lg:px-[25vw]">
@@ -241,25 +253,12 @@ export function SendTab({ recipient }: SendTabProps) {
             userBalance={balance}
             onUseMax={handleUseMax}
           />
-          {showContacts && (
-            <>
-              <Button className="w-full mb-2" onClick={openScanner}>
-                <LuCamera className="mr-2 h-4 w-4" /> Scan QR Code
-              </Button>
-              <ContactsTab
-                onSend={(contact) => {
-                  setToSendData(contact);
-                  setShowContacts(false);
-                }}
-              />
-            </>
-          )}
-          {!showContacts && !toSendData && amountEntered && (
+          {!toSendData && amountEntered && (
             <div className="flex gap-2">
               <Button className="flex-1" onClick={openScanner}>
                 <LuCamera className="mr-2 h-4 w-4" /> Scan QR Code
               </Button>
-              <Button className="flex-1" onClick={() => setShowContacts(true)}>
+              <Button className="flex-1" onClick={openContactsModal}>
                 <LuUsers className="mr-2 h-4 w-4" /> Select Contact
               </Button>
             </div>

--- a/app/tcoin/wallet/components/dashboard/SendTab.tsx
+++ b/app/tcoin/wallet/components/dashboard/SendTab.tsx
@@ -200,7 +200,7 @@ export function SendTab({ recipient }: SendTabProps) {
     (parseFloat(tcoinAmount) || 0) > 0 || (parseFloat(cadAmount) || 0) > 0;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:px-[25vw]">
       <div className="flex gap-2">
         <Button
           variant={mode === "manual" ? "default" : "outline"}

--- a/app/tcoin/wallet/components/dashboard/WalletHome.test.tsx
+++ b/app/tcoin/wallet/components/dashboard/WalletHome.test.tsx
@@ -55,7 +55,6 @@ vi.mock("@tcoin/wallet/components/modals", () => ({
 vi.mock("./ContributionsCard", () => ({
   ContributionsCard: () => <div />,
 }));
-vi.mock("./ReceiveCard", () => ({ ReceiveCard: () => <div /> }));
 const sendCardMock = vi.hoisted(() => vi.fn(() => <div />));
 vi.mock("./SendCard", () => ({
   SendCard: (props: any) => sendCardMock(props),

--- a/app/tcoin/wallet/components/dashboard/types.ts
+++ b/app/tcoin/wallet/components/dashboard/types.ts
@@ -1,3 +1,5 @@
+import type { ContactRecord } from "@shared/api/services/supabaseService";
+
 export interface Hypodata {
   id: number;
   full_name?: string | null;
@@ -6,3 +8,12 @@ export interface Hypodata {
   wallet_address?: string | null;
   state?: string | null;
 }
+
+export const contactRecordToHypodata = (contact: ContactRecord): Hypodata => ({
+  id: contact.id,
+  full_name: contact.full_name ?? undefined,
+  username: contact.username ?? undefined,
+  profile_image_url: contact.profile_image_url ?? undefined,
+  wallet_address: contact.wallet_address ?? undefined,
+  state: contact.state ?? undefined,
+});

--- a/app/tcoin/wallet/components/dashboard/types.ts
+++ b/app/tcoin/wallet/components/dashboard/types.ts
@@ -1,6 +1,8 @@
 export interface Hypodata {
-  id: string;
-  full_name: string;
-  username: string;
-  profile_image_url?: string;
+  id: number;
+  full_name?: string | null;
+  username?: string | null;
+  profile_image_url?: string | null;
+  wallet_address?: string | null;
+  state?: string | null;
 }

--- a/app/tcoin/wallet/components/forms/OTPForm.test.tsx
+++ b/app/tcoin/wallet/components/forms/OTPForm.test.tsx
@@ -88,6 +88,6 @@ describe("OTPForm", () => {
     inputs.forEach((input, idx) => {
       fireEvent.change(input, { target: { value: String(idx) } });
     });
-    expect(onSubmit).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/tcoin/wallet/components/forms/OTPForm.tsx
+++ b/app/tcoin/wallet/components/forms/OTPForm.tsx
@@ -46,18 +46,32 @@ function OTPForm({
 
   const [digits, setDigits] = useState(Array(6).fill(""));
   const inputsRef = useRef([]);
+  const hasAutoSubmittedRef = useRef(false);
 
   useEffect(() => {
     if (isOtpSent) {
       setDigits(Array(6).fill(""));
       setPasscode("");
       inputsRef.current[0]?.focus();
+      hasAutoSubmittedRef.current = false;
     }
   }, [isOtpSent, setPasscode]);
 
   useEffect(() => {
-    if (isOtpSent && digits.every((d) => d !== "")) {
+    if (!isOtpSent) {
+      hasAutoSubmittedRef.current = false;
+      return;
+    }
+
+    const isComplete = digits.every((d) => d !== "");
+
+    if (isComplete && !hasAutoSubmittedRef.current) {
+      hasAutoSubmittedRef.current = true;
       onSubmit(new Event("submit") as any);
+    }
+
+    if (!isComplete) {
+      hasAutoSubmittedRef.current = false;
     }
   }, [isOtpSent, digits, onSubmit]);
 

--- a/app/tcoin/wallet/components/modals/ContactSelectModal.test.tsx
+++ b/app/tcoin/wallet/components/modals/ContactSelectModal.test.tsx
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { act } from "react-dom/test-utils";
@@ -11,18 +11,31 @@ vi.mock("@shared/api/hooks/useAuth", () => ({
   useAuth: () => ({ userData: mockUser }),
 }));
 
-const mockContacts = [
-  { id: 1, state: "accepted", connected_user_id: { id: 2, full_name: "Alice" } },
-];
+const mockContacts = vi.hoisted(() => [
+  {
+    id: 2,
+    full_name: "Alice",
+    username: "alice",
+    profile_image_url: null,
+    wallet_address: null,
+    state: "accepted",
+  },
+]);
+
+const insertMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@shared/lib/supabase/client", () => ({
   createClient: () => ({
     from: () => ({
-      select: () => ({
-        eq: () => Promise.resolve({ data: mockContacts, error: null }),
-      }),
+      insert: insertMock,
     }),
   }),
+}));
+
+const fetchContactsForOwnerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@shared/api/services/supabaseService", () => ({
+  fetchContactsForOwner: fetchContactsForOwnerMock,
 }));
 
 vi.mock("@shared/utils/insertNotification", () => ({
@@ -30,6 +43,12 @@ vi.mock("@shared/utils/insertNotification", () => ({
 }));
 
 describe("ContactSelectModal", () => {
+  beforeEach(() => {
+    fetchContactsForOwnerMock.mockReset();
+    fetchContactsForOwnerMock.mockResolvedValue(mockContacts);
+    insertMock.mockReset();
+  });
+
   it("calls closeModal on Escape key press", () => {
     const closeModal = vi.fn();
     const container = document.createElement("div");
@@ -102,6 +121,57 @@ describe("ContactSelectModal", () => {
     expect(setToSendData).toHaveBeenCalledWith(
       expect.objectContaining({ id: 2, full_name: "Alice" })
     );
+
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+  it("creates an invoice request when the method is Request", async () => {
+    const closeModal = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    insertMock.mockResolvedValue({ data: null });
+
+    const queryClient = new QueryClient();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContactSelectModal
+            closeModal={closeModal}
+            amount="$5"
+            method="Request"
+            setToSendData={vi.fn()}
+          />
+        </QueryClientProvider>
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const requestButton = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent === "Request $5"
+    ) as HTMLButtonElement;
+
+    act(() => {
+      requestButton.click();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(insertMock).toHaveBeenCalledWith({
+      request_from: 2,
+      request_by: 1,
+      amount_requested: 5,
+    });
+    expect(closeModal).toHaveBeenCalled();
 
     act(() => {
       root.unmount();

--- a/app/tcoin/wallet/components/modals/ContactSelectModal.test.tsx
+++ b/app/tcoin/wallet/components/modals/ContactSelectModal.test.tsx
@@ -128,6 +128,42 @@ describe("ContactSelectModal", () => {
     document.body.removeChild(container);
   });
 
+  it("selects the provided default contact id", async () => {
+    const closeModal = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const queryClient = new QueryClient();
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ContactSelectModal
+            closeModal={closeModal}
+            amount="5"
+            method="Send"
+            defaultContactId={2}
+            setToSendData={vi.fn()}
+          />
+        </QueryClientProvider>
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const selectedRadio = container.querySelector<HTMLInputElement>(
+      "input[id='contact-2']"
+    );
+    expect(selectedRadio?.checked).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
   it("creates an invoice request when the method is Request", async () => {
     const closeModal = vi.fn();
     const container = document.createElement("div");

--- a/app/tcoin/wallet/components/modals/ContactSelectModal.tsx
+++ b/app/tcoin/wallet/components/modals/ContactSelectModal.tsx
@@ -1,84 +1,151 @@
-// @ts-nocheck
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Button } from "@shared/components/ui/Button";
 import { Input } from "@shared/components/ui/Input";
 import { Radio } from "@shared/components/ui/Radio";
 import { createClient } from "@shared/lib/supabase/client";
 import { useAuth } from "@shared/api/hooks/useAuth";
+import { fetchContactsForOwner, type ContactRecord } from "@shared/api/services/supabaseService";
 import { insertSuccessNotification } from "@shared/utils/insertNotification";
 import useEscapeKey from "@shared/hooks/useEscapeKey";
+import { Hypodata } from "@tcoin/wallet/components/dashboard";
 
 interface ContactSelectModalProps {
   closeModal: () => void;
   amount: string;
-  setToSendData: any;
+  setToSendData?: (contact: Hypodata) => void;
   method: "Request" | "Send";
 }
+const parseAmountFromString = (raw: string): number | null => {
+  const match = raw.match(/-?\d+(?:\.\d+)?/);
+  if (!match) {
+    return null;
+  }
+  const parsed = Number.parseFloat(match[0]);
+  return Number.isFinite(parsed) ? parsed : null;
+};
 
-interface Contact {
-  value: any;
-  label: string;
-  id: number | string;
-  state: string;
-}
+const formatContactLabel = (contact: ContactRecord) => {
+  const name = contact.full_name?.trim();
+  const username = contact.username?.trim();
+  if (name && username) {
+    return `${name} (@${username})`;
+  }
+  return name || (username ? `@${username}` : "Unknown contact");
+};
 
 const ContactSelectModal = ({ setToSendData, closeModal, amount, method }: ContactSelectModalProps) => {
-  const [selectedContact, setSelectedContact] = useState<any>(null);
-  const [contacts, setContacts] = useState<Contact[]>([]);
-  const [searchTerm, setSearchTerm] = useState<string>("");
-  // activeTab can be "all" or "my"
+  const [contacts, setContacts] = useState<ContactRecord[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
   const [activeTab, setActiveTab] = useState<"all" | "my">("my");
   const { userData } = useAuth();
   useEscapeKey(closeModal);
 
-
   useEffect(() => {
-    async function fetchContacts() {
-      if (!userData?.cubidData?.id) return;
-
-      const supabase = createClient();
-      const { data, error } = await supabase
-        .from("connections")
-        .select("*, connected_user_id(*), state")
-        .eq("owner_user_id", userData.cubidData.id);
-
-      if (error) {
-        console.error("Error fetching contacts:", error);
-      } else if (data) {
-        const mappedContacts = data.map((connection: any) => ({
-          value: connection.connected_user_id,
-          label: connection.connected_user_id?.full_name,
-          id: connection.id,
-          state: connection.state,
-        }));
-
-        const validContacts = mappedContacts.filter((contact: Contact) => contact.state !== "rejected");
-
-        setContacts(validContacts);
-        if (validContacts.length > 0) {
-          setSelectedContact(validContacts[0].value);
-        }
-      }
+    let isMounted = true;
+    const ownerId = userData?.cubidData?.id;
+    if (!ownerId) {
+      setContacts([]);
+      setSelectedId(null);
+      return () => {
+        isMounted = false;
+      };
     }
-    fetchContacts();
-  }, [userData]);
 
-  // Filter by search term
-  const filteredContacts = contacts.filter((contact) =>
-    contact.label.toLowerCase().includes(searchTerm.toLowerCase())
+    fetchContactsForOwner(ownerId)
+      .then((records) => {
+        if (!isMounted) return;
+        setContacts(records);
+        setSelectedId(records[0]?.id ?? null);
+      })
+      .catch((error) => {
+        console.error("Error fetching contacts:", error);
+        if (isMounted) {
+          setContacts([]);
+          setSelectedId(null);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [userData?.cubidData?.id]);
+
+  const filteredContacts = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase();
+    if (!query) return contacts;
+    return contacts.filter((contact) => {
+      const name = contact.full_name?.toLowerCase() ?? "";
+      const username = contact.username?.toLowerCase() ?? "";
+      return name.includes(query) || username.includes(query);
+    });
+  }, [contacts, searchTerm]);
+
+  const allContacts = useMemo(
+    () => filteredContacts.filter((contact) => contact.state === "new"),
+    [filteredContacts]
   );
-
-  // Separate contacts into tabs:
-  // "All Contacts" will show contacts with state "new".
-  // "My Contacts" will show the remaining valid contacts.
-  const allContacts = filteredContacts.filter(contact => contact.state === "new");
-  const myContacts = filteredContacts.filter(contact => contact.state !== "new");
+  const myContacts = useMemo(
+    () => filteredContacts.filter((contact) => contact.state !== "new"),
+    [filteredContacts]
+  );
 
   const contactsToDisplay = activeTab === "all" ? allContacts : myContacts;
 
+  useEffect(() => {
+    if (contactsToDisplay.length === 0) {
+      if (filteredContacts.length === 0) {
+        setSelectedId(null);
+      }
+      return;
+    }
+
+    if (!contactsToDisplay.some((contact) => contact.id === selectedId)) {
+      setSelectedId(contactsToDisplay[0]?.id ?? null);
+    }
+  }, [contactsToDisplay, filteredContacts.length, selectedId]);
+
+  const selectedContact = useMemo(
+    () => contacts.find((contact) => contact.id === selectedId) ?? null,
+    [contacts, selectedId]
+  );
+
+  const handleSubmit = async () => {
+    if (!selectedContact) return;
+
+    if (method === "Send") {
+      setToSendData?.(selectedContact);
+      closeModal();
+      return;
+    }
+
+    const requestBy = userData?.cubidData?.id;
+    const parsedAmount = parseAmountFromString(amount);
+    if (!requestBy || parsedAmount === null) {
+      console.error("Invalid request payload", { requestBy, amount });
+      return;
+    }
+
+    try {
+      const supabase = createClient();
+      await supabase.from("invoice_pay_request").insert({
+        request_from: selectedContact.id,
+        request_by: requestBy,
+        amount_requested: parsedAmount,
+      });
+      insertSuccessNotification({
+        user_id: selectedContact.id,
+        notification: `${amount} request by ${userData?.cubidData?.full_name}`,
+      });
+    } catch (error) {
+      console.error("Failed to create request:", error);
+    } finally {
+      closeModal();
+    }
+  };
+
   return (
     <div className="mt-2 p-0">
-      {/* Tabs */}
       <div className="mb-4 flex">
         <button
           type="button"
@@ -109,45 +176,21 @@ const ContactSelectModal = ({ setToSendData, closeModal, amount, method }: Conta
             <Radio
               name="contact-selection"
               key={contact.id}
-              label={contact.label}
-              value={String(contact.value.id)}
-              onValueChange={() => {
-                setSelectedContact(contact.value)
+              label={formatContactLabel(contact)}
+              value={String(contact.id)}
+              onValueChange={(value) => {
+                const parsed = Number.parseInt(value, 10);
+                setSelectedId(Number.isFinite(parsed) ? parsed : null);
               }}
-              id={String(contact.id)}
-              checked={selectedContact?.id === contact.value.id}
+              id={`contact-${contact.id}`}
+              checked={selectedId === contact.id}
             />
           ))
         ) : (
           <p>No contacts found.</p>
         )}
 
-        <Button
-          className="w-full"
-          disabled={!selectedContact}
-          onClick={async () => {
-            if (method === "Send") {
-              setToSendData(selectedContact);
-            }
-            if (method === "Request") {
-              function extractDecimalFromString(str: string): number {
-                const match = str.match(/-?\d+(\.\d+)?/);
-                return match ? Number(match[0]) : NaN;
-              }
-              const supabase = createClient();
-              await supabase.from("invoice_pay_request").insert({
-                request_from: parseInt(selectedContact.id),
-                request_by: userData?.cubidData?.id,
-                amount_requested: extractDecimalFromString(amount)
-              })
-              insertSuccessNotification({
-                user_id: parseInt(selectedContact.id),
-                notification: `${amount} request by ${userData?.cubidData?.full_name}`
-              })
-            }
-            closeModal();
-          }}
-        >
+        <Button className="w-full" disabled={!selectedContact} onClick={handleSubmit}>
           {method} {amount}
         </Button>
       </div>

--- a/app/tcoin/wallet/dashboard/page.tsx
+++ b/app/tcoin/wallet/dashboard/page.tsx
@@ -10,12 +10,15 @@ import {
 import { DashboardFooter } from "@tcoin/wallet/components/DashboardFooter";
 import { ErrorBoundary } from "@shared/components/ErrorBoundary";
 import { useRouter } from "next/navigation";
+import type { ContactRecord } from "@shared/api/services/supabaseService";
+import type { Hypodata } from "@tcoin/wallet/components/dashboard";
 
 export default function Dashboard() {
   const { userData, error, isLoadingUser } = useAuth();
   const [activeTab, setActiveTab] = useState("home");
-  const [sendRecipient, setSendRecipient] = useState<any>(null);
-  const [requestRecipient, setRequestRecipient] = useState<any>(null);
+  const [sendRecipient, setSendRecipient] = useState<Hypodata | null>(null);
+  const [requestRecipient, setRequestRecipient] = useState<Hypodata | null>(null);
+  const [cachedContacts, setCachedContacts] = useState<ContactRecord[] | null>(null);
   const router = useRouter();
 
   const mainClass = "font-sans pb-24 p-4 sm:p-8 bg-background text-foreground min-h-screen";
@@ -28,28 +31,42 @@ export default function Dashboard() {
     if (activeTab === "contacts") {
       return (
         <ContactsTab
+          initialContacts={cachedContacts ?? undefined}
+          onContactsResolved={(records) => setCachedContacts(records)}
           onSend={(contact) => {
-            setSendRecipient(contact);
+            setSendRecipient({ ...contact });
             setActiveTab("send");
           }}
           onRequest={(contact) => {
-            setRequestRecipient(contact);
+            setRequestRecipient({ ...contact });
             setActiveTab("receive");
           }}
         />
       );
     }
     if (activeTab === "send") {
-      return <SendTab recipient={sendRecipient} />;
+      return (
+        <SendTab
+          recipient={sendRecipient}
+          onRecipientChange={setSendRecipient}
+          contacts={cachedContacts ?? undefined}
+        />
+      );
     }
     if (activeTab === "receive") {
-      return <ReceiveTab contact={requestRecipient} />;
+      return (
+        <ReceiveTab
+          contact={requestRecipient}
+          onContactChange={setRequestRecipient}
+          contacts={cachedContacts ?? undefined}
+        />
+      );
     }
     const label = activeTab.charAt(0).toUpperCase() + activeTab.slice(1);
     return (
       <div className="flex items-center justify-center h-full">{`${label} screen coming soon`}</div>
     );
-  }, [activeTab, isLoadingUser, error, sendRecipient, requestRecipient]);
+  }, [activeTab, isLoadingUser, error, sendRecipient, requestRecipient, cachedContacts]);
 
   useEffect(() => {
     if (Boolean(userData?.cubidData?.full_name)) {

--- a/app/tcoin/wallet/dashboard/page.tsx
+++ b/app/tcoin/wallet/dashboard/page.tsx
@@ -22,14 +22,7 @@ export default function Dashboard() {
   const content = useMemo(() => {
     if (isLoadingUser || error) return null;
     if (activeTab === "home") {
-      return (
-        <WalletHome
-          qrBgColor="#fff"
-          qrFgColor="#000"
-          qrWrapperClassName="bg-white p-1"
-          tokenLabel="TCOIN"
-        />
-      );
+      return <WalletHome tokenLabel="TCOIN" />;
     }
     if (activeTab === "contacts") {
       return (

--- a/app/tcoin/wallet/dashboard/page.tsx
+++ b/app/tcoin/wallet/dashboard/page.tsx
@@ -15,6 +15,7 @@ export default function Dashboard() {
   const { userData, error, isLoadingUser } = useAuth();
   const [activeTab, setActiveTab] = useState("home");
   const [sendRecipient, setSendRecipient] = useState<any>(null);
+  const [requestRecipient, setRequestRecipient] = useState<any>(null);
   const router = useRouter();
 
   const mainClass = "font-sans pb-24 p-4 sm:p-8 bg-background text-foreground min-h-screen";
@@ -31,6 +32,10 @@ export default function Dashboard() {
             setSendRecipient(contact);
             setActiveTab("send");
           }}
+          onRequest={(contact) => {
+            setRequestRecipient(contact);
+            setActiveTab("receive");
+          }}
         />
       );
     }
@@ -38,13 +43,13 @@ export default function Dashboard() {
       return <SendTab recipient={sendRecipient} />;
     }
     if (activeTab === "receive") {
-      return <ReceiveTab />;
+      return <ReceiveTab contact={requestRecipient} />;
     }
     const label = activeTab.charAt(0).toUpperCase() + activeTab.slice(1);
     return (
       <div className="flex items-center justify-center h-full">{`${label} screen coming soon`}</div>
     );
-  }, [activeTab, isLoadingUser, error, sendRecipient]);
+  }, [activeTab, isLoadingUser, error, sendRecipient, requestRecipient]);
 
   useEffect(() => {
     if (Boolean(userData?.cubidData?.full_name)) {

--- a/shared/api/hooks/useAuth.test.tsx
+++ b/shared/api/hooks/useAuth.test.tsx
@@ -1,0 +1,153 @@
+import React, { type ReactNode } from "react";
+import type { Session } from "@supabase/supabase-js";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authStateChangeHandlerRef = vi.hoisted(() => ({
+  current: null as ((event: string, session: Session | null) => void) | null,
+}));
+const unsubscribeMock = vi.hoisted(() => vi.fn());
+const onAuthStateChangeMock = vi.hoisted(() =>
+  vi.fn((callback: (event: string, session: Session | null) => void) => {
+    authStateChangeHandlerRef.current = callback;
+    return { data: { subscription: { unsubscribe: unsubscribeMock } } };
+  })
+);
+const createClientMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    auth: {
+      onAuthStateChange: onAuthStateChangeMock,
+    },
+  }))
+);
+
+vi.mock("@shared/lib/supabase/client", () => ({
+  __esModule: true,
+  createClient: createClientMock,
+}));
+
+const mockGetSession = vi.hoisted(() => vi.fn());
+const mockFetchUserByContact = vi.hoisted(() => vi.fn());
+const mockFetchCubidDataFromSupabase = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/supabaseService", () => ({
+  __esModule: true,
+  fetchUserByContact: mockFetchUserByContact,
+  fetchCubidDataFromSupabase: mockFetchCubidDataFromSupabase,
+  getSession: mockGetSession,
+  signOut: vi.fn(),
+  updateCubidDataInSupabase: vi.fn(),
+}));
+
+vi.mock("../services/cubidService", () => ({
+  __esModule: true,
+  fetchCubidData: vi.fn(),
+}));
+
+import { useAuth } from "./useAuth";
+
+const createTestSession = (): Session =>
+  ({
+    access_token: "access-token",
+    token_type: "bearer",
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: "refresh-token",
+    user: {
+      id: "user-id",
+      aud: "authenticated",
+      email: "user@example.com",
+      app_metadata: { provider: "email" },
+      user_metadata: {},
+      created_at: new Date().toISOString(),
+    },
+  } as unknown as Session);
+
+const baseCubidData = {
+  full_name: "Test User",
+  username: "testuser",
+  email: "user@example.com",
+  phone: "",
+  address: "",
+  bio: "",
+  profile_image_url: null,
+  preferred_donation_amount: 0,
+  selected_cause: "",
+  good_tip: null,
+  default_tip: null,
+  persona: null,
+  current_step: 0,
+  category: "",
+  updated_at: new Date().toISOString(),
+};
+
+describe("useAuth", () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    authStateChangeHandlerRef.current = null;
+    createClientMock.mockClear();
+    onAuthStateChangeMock.mockClear();
+    unsubscribeMock.mockClear();
+    mockGetSession.mockReset();
+    mockFetchUserByContact.mockReset();
+    mockFetchCubidDataFromSupabase.mockReset();
+
+    mockGetSession.mockResolvedValue(null);
+    mockFetchUserByContact.mockResolvedValue({
+      user: { cubid_id: "cubid-id", has_completed_intro: true },
+      error: null,
+    });
+    mockFetchCubidDataFromSupabase.mockResolvedValue(baseCubidData);
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it("sets the user as authenticated when Supabase emits a sign-in event", async () => {
+    const { result, unmount } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(onAuthStateChangeMock).toHaveBeenCalled();
+      expect(typeof authStateChangeHandlerRef.current).toBe("function");
+    });
+
+    act(() => {
+      authStateChangeHandlerRef.current?.("SIGNED_IN", createTestSession());
+    });
+
+    await waitFor(() => {
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(mockFetchUserByContact).toHaveBeenCalled();
+    });
+
+    unmount();
+  });
+
+  it("cleans up the Supabase auth subscription on unmount", async () => {
+    const { unmount } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(onAuthStateChangeMock).toHaveBeenCalled();
+    });
+
+    unmount();
+
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+});

--- a/shared/api/services/supabaseService.ts
+++ b/shared/api/services/supabaseService.ts
@@ -46,8 +46,7 @@ export const fetchContactsForOwner = async (ownerUserId: number | string | null 
   const { data: connectionRows, error } = await supabase
     .from("connections")
     .select("connected_user_id, state")
-    .eq("owner_user_id", ownerId)
-    .neq("state", "rejected");
+    .eq("owner_user_id", ownerId);
 
   if (error) {
     throw error;
@@ -61,8 +60,13 @@ export const fetchContactsForOwner = async (ownerUserId: number | string | null 
     if (id === null || seen.has(id)) {
       continue;
     }
+    const rawState = typeof row.state === "string" ? row.state.trim() : null;
+    const state = rawState ? rawState.toLowerCase() : null;
+    if (state === "rejected") {
+      continue;
+    }
     seen.add(id);
-    dedupedConnections.push({ id, state: row.state ?? null });
+    dedupedConnections.push({ id, state });
   }
 
   if (dedupedConnections.length === 0) {

--- a/shared/hooks/useGetLatestExchangeRate.test.tsx
+++ b/shared/hooks/useGetLatestExchangeRate.test.tsx
@@ -1,0 +1,65 @@
+/** @vitest-environment jsdom */
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useControlVariables } from "./useGetLatestExchangeRate";
+
+const createClientMock = vi.hoisted(() => vi.fn());
+const matchMock = vi.fn();
+const selectMock = vi.fn();
+const fromMock = vi.fn();
+
+vi.mock("@shared/lib/supabase/client", () => ({
+  createClient: createClientMock,
+}));
+
+describe("useControlVariables", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    matchMock.mockReset();
+    selectMock.mockReset();
+    fromMock.mockReset();
+    createClientMock.mockReset();
+
+    selectMock.mockImplementation(() => ({ match: matchMock }));
+    fromMock.mockImplementation(() => ({ select: selectMock }));
+    createClientMock.mockImplementation(() => ({ from: fromMock }));
+  });
+
+  it("returns fetched exchange rate when available", async () => {
+    matchMock.mockResolvedValue({ data: [{ value: 7.12 }], error: null });
+
+    const { result } = renderHook(() => useControlVariables());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(createClientMock).toHaveBeenCalled();
+    expect(fromMock).toHaveBeenCalledWith("control_variables");
+    expect(selectMock).toHaveBeenCalledWith("*");
+    expect(matchMock).toHaveBeenCalledWith({ variable: "exchange_rate" });
+    expect(result.current.exchangeRate).toBe(7.12);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("skips fetching when not running in the browser", async () => {
+    const { result } = renderHook(() => useControlVariables({ isBrowser: false }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(createClientMock).not.toHaveBeenCalled();
+    expect(result.current.exchangeRate).toBe(3.35);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("captures errors thrown during fetch", async () => {
+    const thrownError = new Error("boom");
+    matchMock.mockRejectedValue(thrownError);
+
+    const { result } = renderHook(() => useControlVariables());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(thrownError);
+  });
+});


### PR DESCRIPTION
## Summary
- subscribe to Supabase auth state changes to refresh cached session and user data
- add tests that exercise the Supabase auth subscription handling

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c8b304d34083249d9faf4afd80e6fb