### PR TITLE
chore: add Supabase schema snapshot

### DIFF
--- a/agent-context/session-log.md
+++ b/agent-context/session-log.md
@@ -1,3 +1,6 @@
+## v0.63
+- Pulled the Supabase OpenAPI metadata and generated `sql-schema-v0.sql` capturing tables, enums, and exposed RPC signatures.
+
 ## v0.62
 - Secured Ecosystem links with `rel="noopener noreferrer"` and added tests.
 

--- a/agent-context/technical-spec.md
+++ b/agent-context/technical-spec.md
@@ -14,6 +14,7 @@
 - **Authentication**: Twilio SMS OTP via API routes
 - **Storage**: Supabase (Postgres + Auth)
   - Browser storage (e.g. `localStorage`) is accessed inside `useEffect` hooks with window guards to avoid Node build-time warnings
+  - `agent-context/sql-schema-v0.sql` snapshots the current public schema (tables, enums, RPC signatures) pulled via the Supabase OpenAPI using the anon key; function bodies remain server-side
 - **Wallet/Identity**: Cubid (web3 login + wallet abstraction)
 - **CI**: GitHub workflow installs dependencies with `pnpm install --no-frozen-lockfile`
 


### PR DESCRIPTION
## Summary
- pull Supabase OpenAPI metadata with the anon key and generate `agent-context/sql-schema-v0.sql` containing enums, table DDL, and RPC signatures
- note the new schema snapshot in the technical specification and record the session update

## Testing
- pnpm lint *(passes with existing warnings in sparechange and wallet lint rules)*
- pnpm test *(fails: existing IndexedDB/localStorage errors from cubid-wallet mocks)*
- pnpm build *(passes with IndexedDB/localStorage warnings during static generation)*

------
https://chatgpt.com/codex/tasks/task_e_68d003fb23a0832481040b77b18b1ef1