### PR TITLE
feat: link connections to app user profiles

### DIFF
--- a/supabase/migrations/v0.70_connections_profile_fks.sql
+++ b/supabase/migrations/v0.70_connections_profile_fks.sql
@@ -1,0 +1,35 @@
+-- migrate:up
+BEGIN;
+
+ALTER TABLE IF EXISTS public.connections
+  DROP CONSTRAINT IF EXISTS connections_owner_user_id_fkey,
+  DROP CONSTRAINT IF EXISTS connections_connected_user_id_fkey;
+
+ALTER TABLE IF EXISTS public.connections
+  ADD CONSTRAINT connections_owner_profile_fkey
+    FOREIGN KEY (owner_user_id, app_instance_id)
+    REFERENCES public.app_user_profiles (user_id, app_instance_id)
+    ON DELETE CASCADE,
+  ADD CONSTRAINT connections_connected_profile_fkey
+    FOREIGN KEY (connected_user_id, app_instance_id)
+    REFERENCES public.app_user_profiles (user_id, app_instance_id)
+    ON DELETE CASCADE;
+
+COMMIT;
+
+-- migrate:down
+BEGIN;
+
+ALTER TABLE IF EXISTS public.connections
+  DROP CONSTRAINT IF EXISTS connections_owner_profile_fkey,
+  DROP CONSTRAINT IF EXISTS connections_connected_profile_fkey;
+
+ALTER TABLE IF EXISTS public.connections
+  ADD CONSTRAINT connections_owner_user_id_fkey
+    FOREIGN KEY (owner_user_id)
+    REFERENCES public.users (id),
+  ADD CONSTRAINT connections_connected_user_id_fkey
+    FOREIGN KEY (connected_user_id)
+    REFERENCES public.users (id);
+
+COMMIT;

--- a/supabase/sql-schema.sql
+++ b/supabase/sql-schema.sql
@@ -244,9 +244,11 @@ CREATE TABLE IF NOT EXISTS public."connections" (
   "state" public.connection_state DEFAULT 'new' NOT NULL,
   "created_at" timestamp with time zone DEFAULT now() NOT NULL,
   "modified_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "app_instance_id" bigint NOT NULL,
   PRIMARY KEY ("id"),
-  FOREIGN KEY ("owner_user_id") REFERENCES public."users"("id"),
-  FOREIGN KEY ("connected_user_id") REFERENCES public."users"("id")
+  CONSTRAINT connections_app_instance_id_fkey FOREIGN KEY ("app_instance_id") REFERENCES public."ref_app_instances"("id"),
+  CONSTRAINT connections_owner_profile_fkey FOREIGN KEY ("owner_user_id", "app_instance_id") REFERENCES public."app_user_profiles"("user_id", "app_instance_id") ON DELETE CASCADE,
+  CONSTRAINT connections_connected_profile_fkey FOREIGN KEY ("connected_user_id", "app_instance_id") REFERENCES public."app_user_profiles"("user_id", "app_instance_id") ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS public."control_variables" (


### PR DESCRIPTION
## Summary
- add migration that replaces connections.user foreign keys with composite references to app_user_profiles and cascade deletions
- refresh the SQL schema to include the new composite constraints and app instance column

## Testing
- pnpm lint
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d19acc2d608324af0160d838a7ec27